### PR TITLE
Refactor file structure and performance tuning

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -3,4 +3,7 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   roots: ['<rootDir>/tests'],
+  moduleNameMapper: {
+    '^@/(.+)': '<rootDir>/src/$1',
+  },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
-type DividerResult<
-  T extends string | string[],
-  F extends boolean | undefined,
-> = T extends string ? string[] : F extends true ? string[] : string[][];
+import type { DividerResult } from '@/utils/types';
+import { sliceByIndexes } from '@/utils/slice';
+import { getRegex } from '@/utils/regex';
 
 export function divider<T extends string | string[]>(
   input: string | string[],
@@ -31,10 +30,7 @@ export function divider<T extends string | string[]>(
     divideString(item, numSeparators, strSeparators)
   );
 
-  return (options.flatten ? result.flat() : result) as DividerResult<
-    T,
-    boolean
-  >;
+  return (options.flatten ? result.flat() : result) as DividerResult<T>;
 }
 
 function divideString(
@@ -47,44 +43,19 @@ function divideString(
   }
 
   // Precompile regex for string separators
-  const regex = strSeparators.length
-    ? new RegExp(`[${strSeparators.map(escapeRegExp).join('')}]`, 'g')
-    : null;
+  const regex = getRegex(strSeparators);
 
   // Divide by number delimiters
   let parts: string[] = sliceByIndexes(input, numSeparators);
 
   // Divide by string delimiters
   if (regex) {
-    parts = parts.flatMap((part) => part.split(regex!)).filter(Boolean);
+    parts = parts.flatMap((part) => part.split(regex)).filter(Boolean);
   }
 
   return parts;
 }
 
-function sliceByIndexes(input: string, indexes: number[]): string[] {
-  if (!indexes.length) return [input];
-
-  const sortedIndexes = indexes.slice().sort((a, b) => a - b);
-  const parts = new Array(sortedIndexes.length + 1).fill(null);
-  let start = 0;
-
-  for (let i = 0; i < sortedIndexes.length; i++) {
-    const index = sortedIndexes[i];
-    if (index > start && index < input.length) {
-      parts[i] = input.slice(start, index);
-      start = index;
-    }
-  }
-
-  parts[sortedIndexes.length] = input.slice(start);
-  return parts.filter(Boolean);
-}
-
 function isOptions(arg: unknown): arg is { flatten?: boolean } {
   return typeof arg === 'object' && arg !== null && 'flatten' in arg;
-}
-
-function escapeRegExp(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -1,0 +1,17 @@
+const regexCache = new Map<string, RegExp>();
+
+export function getRegex(separators: string[]): RegExp | null {
+  if (separators.length === 0) return null;
+  const key = separators.join('');
+  if (!regexCache.has(key)) {
+    regexCache.set(
+      key,
+      new RegExp(`[${separators.map(escapeRegExp).join('')}]`, 'g')
+    );
+  }
+  return regexCache.get(key)!;
+}
+
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/utils/slice.ts
+++ b/src/utils/slice.ts
@@ -1,0 +1,17 @@
+export function sliceByIndexes(input: string, indexes: number[]): string[] {
+  if (!indexes.length) return [input];
+
+  const sortedIndexes = indexes.slice().sort((a, b) => a - b);
+  const parts: string[] = [];
+  let start = 0;
+
+  for (const index of sortedIndexes) {
+    if (index > start && index < input.length) {
+      parts.push(input.slice(start, index));
+      start = index;
+    }
+  }
+
+  parts.push(input.slice(start));
+  return parts.filter(Boolean);
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,4 @@
+export type DividerResult<
+  T extends string | string[],
+  F extends boolean = false,
+> = T extends string ? string[] : F extends true ? string[] : string[][];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,10 @@
     "target": "ES6",
     "declarationDir": "dist",
     "strict": true,
-    "declaration": true
+    "declaration": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist", "tests"]


### PR DESCRIPTION
I update below

- File structure
  - Divide index file to `regex`, `slice` and `types`
  - Create `utils` directory and put in these files
  - Fix config to add path `@`. That means `/src`
- Type definition
  - Fix DividerResult second argument to use default option of false
- Performance tuning
  - Create a regexCache and reuse this.