### PR TITLE
Fix regex key

### DIFF
--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -2,13 +2,17 @@ const regexCache = new Map<string, RegExp>();
 
 export function getRegex(separators: string[]): RegExp | null {
   if (separators.length === 0) return null;
-  const key = separators.join('');
+
+  const key = JSON.stringify(separators);
+
   if (!regexCache.has(key)) {
-    regexCache.set(
-      key,
-      new RegExp(`[${separators.map(escapeRegExp).join('')}]`, 'g')
+    const pattern = separators.reduce(
+      (acc, sep) => acc + escapeRegExp(sep),
+      ''
     );
+    regexCache.set(key, new RegExp(`[${pattern}]`, 'g'));
   }
+
   return regexCache.get(key)!;
 }
 


### PR DESCRIPTION
There had redundant join logic, so I fix the logic not to use join.

- The regex key is created by Json.stringify because the separator was unsafe. For example, ["ab", "c"] and ["abc"] are same key while using join method.
- Eliminate unnecessary join methods.

