### PR TITLE
Input type validation and console warn

### DIFF
--- a/src/core/divider.ts
+++ b/src/core/divider.ts
@@ -6,7 +6,10 @@ export function divider<T extends string | string[]>(
   input: string | string[],
   ...args: (number | string | { flatten?: boolean })[]
 ): DividerResult<T> {
-  if (input === null || input === undefined) {
+  if (typeof input !== 'string' && !Array.isArray(input)) {
+    console.warn(
+      "divider: 'input' must be a string or an array of strings. So returning an empty array."
+    );
     return [];
   }
 


### PR DESCRIPTION
If `input` is not correct type, return empty array and show console warn because the user can't understand why the returning value is empty array.

Console error would make alert if user use Datadog or Sentry or etc, so using console warn.