### PR TITLE
Fix renovate setting

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,8 +6,7 @@
   "commitMessagePrefix": "chore(deps): ",
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
+      "matchUpdateTypes": ["minor", "patch"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Remove unnecessary setting

<!-- A brief summary of the changes -->

## Description

`automerge` setting is not needed and conflict setting value

<!-- A detailed explanation of the changes, including why they are needed -->
