### PR TITLE
Fix to remove magic number

### DIFF
--- a/src/core/divider.ts
+++ b/src/core/divider.ts
@@ -1,6 +1,6 @@
 import type { DividerResult, DividerArgs } from '@/core/types';
 import { divideString } from '@/core/parser';
-import { isOptions } from '@/core/validator';
+import { isOptions, isEmptyArray } from '@/core/validator';
 
 export function divider<T extends string | string[], F extends boolean>(
   input: T,
@@ -13,7 +13,7 @@ export function divider<T extends string | string[], F extends boolean>(
     return [];
   }
 
-  if (args.length === 0) {
+  if (isEmptyArray(args)) {
     return (typeof input === 'string' ? [input] : input) as DividerResult<T, F>;
   }
 

--- a/src/core/validator.ts
+++ b/src/core/validator.ts
@@ -1,3 +1,7 @@
 export function isOptions(arg: unknown): arg is { flatten?: boolean } {
   return typeof arg === 'object' && arg !== null && 'flatten' in arg;
 }
+
+export function isEmptyArray<T>(input: T[]): boolean {
+  return input.length === 0;
+}


### PR DESCRIPTION
## Summary

Fix to remove magic number

## Description

Add `isEmptyArray` and remove magic number definition.

<!-- A detailed explanation of the changes, including why they are needed -->
