### PR TITLE
Fix validator to is

### DIFF
--- a/src/core/divider.ts
+++ b/src/core/divider.ts
@@ -1,6 +1,6 @@
 import type { DividerResult, DividerArgs } from '@/core/types';
 import { divideString } from '@/core/parser';
-import { isOptions, isEmptyArray } from '@/core/validator';
+import { isOptions, isEmptyArray } from '@/utils/is';
 
 export function divider<T extends string | string[], F extends boolean>(
   input: T,

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -1,12 +1,13 @@
-import { sliceByIndexes } from '@/utils/slice';
+import { isEmptyArray } from '@/utils/is';
 import { getRegex } from '@/utils/regex';
+import { sliceByIndexes } from '@/utils/slice';
 
 export function divideString(
   input: string,
   numSeparators: number[],
   strSeparators: string[]
 ): string[] {
-  if (numSeparators.length === 0 && strSeparators.length === 0) {
+  if (isEmptyArray(numSeparators) && isEmptyArray(strSeparators)) {
     return [input];
   }
 

--- a/src/utils/is.ts
+++ b/src/utils/is.ts
@@ -3,5 +3,5 @@ export function isOptions(arg: unknown): arg is { flatten?: boolean } {
 }
 
 export function isEmptyArray<T>(input: T[]): boolean {
-  return input.length === 0;
+  return Array.isArray(input) && input.length === 0;
 }

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -1,7 +1,9 @@
+import { isEmptyArray } from '@/utils/is';
+
 const regexCache = new Map<string, RegExp>();
 
 export function getRegex(separators: string[]): RegExp | null {
-  if (separators.length === 0) return null;
+  if (isEmptyArray(separators)) return null;
 
   const key = JSON.stringify(separators);
 

--- a/src/utils/slice.ts
+++ b/src/utils/slice.ts
@@ -1,5 +1,7 @@
+import { isEmptyArray } from '@/utils/is';
+
 export function sliceByIndexes(input: string, indexes: number[]): string[] {
-  if (indexes.length === 0) return [input];
+  if (isEmptyArray(indexes)) return [input];
 
   const parts: string[] = [];
   let start = 0;

--- a/tests/core/is.test.ts
+++ b/tests/core/is.test.ts
@@ -1,4 +1,4 @@
-import { isOptions } from '../../src//core/validator';
+import { isOptions, isEmptyArray } from '../../src/utils/is';
 
 describe('isOptions', () => {
   test('true for valid options object', () => {
@@ -21,5 +21,24 @@ describe('isOptions', () => {
     expect(isOptions('string')).toBe(false);
     expect(isOptions([])).toBe(false);
     expect(isOptions(() => {})).toBe(false);
+  });
+});
+
+describe('isEmptyArray', () => {
+  test('true for an empty array', () => {
+    expect(isEmptyArray([])).toBe(true);
+  });
+
+  test('false for a non-empty array', () => {
+    expect(isEmptyArray([1])).toBe(false);
+    expect(isEmptyArray(['a', 'b'])).toBe(false);
+  });
+
+  test('false for non-array inputs', () => {
+    expect(isEmptyArray(undefined as any)).toBe(false);
+    expect(isEmptyArray(null as any)).toBe(false);
+    expect(isEmptyArray('' as any)).toBe(false);
+    expect(isEmptyArray(0 as any)).toBe(false);
+    expect(isEmptyArray({} as any)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Fix validator to is

<!-- A brief summary of the changes -->

## Description

- Rename file `validator` to `is`
- Add `isEmptyArray` test
- Fix `isEmptyArray` logic to avoid unexpected error
- Horizontal development of `isEmptyArray`

<!-- A detailed explanation of the changes, including why they are needed -->
