### PR TITLE
Fix dividerLast args structure

### DIFF
--- a/src/core/divider-last.ts
+++ b/src/core/divider-last.ts
@@ -1,15 +1,11 @@
 import { divider } from '@/core/divider';
-import type { DividerArgs } from '@/core/types';
+import type { DividerSeparators } from '@/core/types';
 
-export function dividerLast<
-  T extends string | string[],
-  F extends boolean = false,
->(input: T, ...args: DividerArgs<F>): string {
-  const result = divider(input, ...args);
+export function dividerLast<T extends string | string[]>(
+  input: T,
+  ...args: DividerSeparators
+): string {
+  const result = divider(input, ...args, { flatten: true });
 
-  if (result.length === 0) return '';
-
-  const lastElement = result[result.length - 1];
-
-  return Array.isArray(lastElement) ? (lastElement.at(-1) ?? '') : lastElement;
+  return result.at(-1) ?? '';
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -5,6 +5,8 @@ export type DividerResult<
 
 export type DividerOptions<F extends boolean> = { flatten?: F };
 
+export type DividerSeparators = (number | string)[];
+
 export type DividerArgs<F extends boolean> =
-  | (number | string)[]
-  | [...(number | string)[], DividerOptions<F>];
+  | DividerSeparators
+  | [...DividerSeparators, DividerOptions<F>];

--- a/tests/core/divider-last.test.ts
+++ b/tests/core/divider-last.test.ts
@@ -22,16 +22,6 @@ const runDividerLastTests = (label: string, input: string | string[]) => {
       expect(dividerLast(input, 'e', 'l')).toEqual('d');
     });
 
-    describe('flat option', () => {
-      test('default (false)', () => {
-        expect(dividerLast(input, 2, { flatten: false })).toEqual('rld');
-      });
-
-      test('explicit true', () => {
-        expect(dividerLast(input, 2, { flatten: true })).toEqual('rld');
-      });
-    });
-
     test('empty separators', () => {
       expect(dividerLast(input, ...([] as const))).toEqual('world');
     });


### PR DESCRIPTION
## Summary

Fix dividerLast args structure

<!-- A brief summary of the changes -->

## Description

`dividerLast` returns only string so there is no need to get args of `flatten`.

`dividerLast` only needs `DividerSeparators`

- Create new type of `DividerSeparators`
- Remove unnecessary args of `flatten` from `dividerLast`

<!-- A detailed explanation of the changes, including why they are needed -->
