### PR TITLE
Fix dividerFirst args structure

### DIFF
--- a/src/core/divider-first.ts
+++ b/src/core/divider-first.ts
@@ -1,15 +1,11 @@
 import { divider } from '@/core/divider';
-import type { DividerArgs } from '@/core/types';
+import type { DividerSeparators } from '@/core/types';
 
-export function dividerFirst<
-  T extends string | string[],
-  F extends boolean = false,
->(input: T, ...args: DividerArgs<F>): string {
-  const result = divider(input, ...args);
-
-  if (Array.isArray(result[0])) {
-    return result[0][0] ?? '';
-  }
+export function dividerFirst<T extends string | string[]>(
+  input: T,
+  ...args: DividerSeparators
+): string {
+  const result = divider(input, ...args, { flatten: true });
 
   return result[0] ?? '';
 }

--- a/tests/core/divider-first.test.ts
+++ b/tests/core/divider-first.test.ts
@@ -22,16 +22,6 @@ const runDividerFirstTests = (label: string, input: string | string[]) => {
       expect(dividerFirst(input, 'e', 'l')).toEqual('h');
     });
 
-    describe('flat option', () => {
-      test('default (false)', () => {
-        expect(dividerFirst(input, 2, { flatten: false })).toEqual('he');
-      });
-
-      test('explicit true', () => {
-        expect(dividerFirst(input, 2, { flatten: true })).toEqual('he');
-      });
-    });
-
     test('empty separators', () => {
       expect(dividerFirst(input, ...([] as const))).toEqual('hello');
     });


### PR DESCRIPTION
## Summary

Fix dividerFirst args structure

<!-- A brief summary of the changes -->

## Description

`dividerFirst` returns only string so there is no need to get args of `flatten`.

`dividerFirst` only needs `DividerSeparators`

- Remove unnecessary args of `flatten` from `dividerFirst`

<!-- A detailed explanation of the changes, including why they are needed -->
