### PR TITLE
Fix unnecessary generics

### DIFF
--- a/src/core/divider-first.ts
+++ b/src/core/divider-first.ts
@@ -1,8 +1,8 @@
 import { divider } from '@/core/divider';
 import type { DividerSeparators } from '@/core/types';
 
-export function dividerFirst<T extends string | string[]>(
-  input: T,
+export function dividerFirst(
+  input: string | string[],
   ...args: DividerSeparators
 ): string {
   const result = divider(input, ...args, { flatten: true });

--- a/src/core/divider-last.ts
+++ b/src/core/divider-last.ts
@@ -1,8 +1,8 @@
 import { divider } from '@/core/divider';
 import type { DividerSeparators } from '@/core/types';
 
-export function dividerLast<T extends string | string[]>(
-  input: T,
+export function dividerLast(
+  input: string | string[],
   ...args: DividerSeparators
 ): string {
   const result = divider(input, ...args, { flatten: true });


### PR DESCRIPTION
## Summary

Fix unnecessary generics of `dividerFirst` and `dividerLast`

<!-- A brief summary of the changes -->

## Description

After removing arguments of flatten, there is no need to use generics type.

It is more simpler.

<!-- A detailed explanation of the changes, including why they are needed -->
