### PR TITLE
Remove unused flatten option and add isPositiveInteger

### DIFF
--- a/src/core/divider-loop.ts
+++ b/src/core/divider-loop.ts
@@ -1,4 +1,4 @@
-import { isString, isNumber } from '@/utils/is';
+import { isString, isPositiveInteger } from '@/utils/is';
 import { generateIndexes } from '@/utils/chunk';
 import type { DividerOptions, DividerResult } from '@/core/types';
 import { divider } from '@/core/divider';
@@ -8,16 +8,14 @@ export function dividerLoop<T extends string | string[], F extends boolean>(
   size: number,
   options?: DividerOptions<F>
 ): DividerResult<T, F> {
-  if (!isNumber(size) || size <= 0) {
+  if (!isPositiveInteger(size)) {
     console.warn('dividerLoop: chunk size must be a positive number');
     return [];
   }
 
-  const flatten = options?.flatten ?? false;
-
   if (isString(input)) {
     const indexes = generateIndexes(input, size);
-    return divider(input, ...indexes, { flatten }) as DividerResult<T, F>;
+    return divider(input, ...indexes) as DividerResult<T, F>;
   }
 
   const result = input.map((item) => {
@@ -25,5 +23,6 @@ export function dividerLoop<T extends string | string[], F extends boolean>(
     return divider(item, ...indexes);
   });
 
+  const flatten = options?.flatten ?? false;
   return (flatten ? result.flat() : result) as DividerResult<T, F>;
 }

--- a/src/utils/is.ts
+++ b/src/utils/is.ts
@@ -11,3 +11,7 @@ export function isOptions(arg: unknown): arg is { flatten?: boolean } {
 export function isEmptyArray<T>(input: T[]): boolean {
   return Array.isArray(input) && input.length === 0;
 }
+
+export function isPositiveInteger(value: unknown): boolean {
+  return Number.isInteger(value) && (value as number) > 0;
+}

--- a/tests/core/is.test.ts
+++ b/tests/core/is.test.ts
@@ -1,4 +1,4 @@
-import { isOptions, isEmptyArray } from '../../src/utils/is';
+import { isOptions, isEmptyArray, isPositiveInteger } from '../../src/utils/is';
 
 describe('isOptions', () => {
   test('true for valid options object', () => {
@@ -40,5 +40,35 @@ describe('isEmptyArray', () => {
     expect(isEmptyArray('' as any)).toBe(false);
     expect(isEmptyArray(0 as any)).toBe(false);
     expect(isEmptyArray({} as any)).toBe(false);
+  });
+});
+
+describe('isPositiveInteger', () => {
+  test('returns true for positive integers', () => {
+    expect(isPositiveInteger(1)).toBe(true);
+    expect(isPositiveInteger(100)).toBe(true);
+  });
+
+  test('returns false for zero', () => {
+    expect(isPositiveInteger(0)).toBe(false);
+  });
+
+  test('returns false for negative integers', () => {
+    expect(isPositiveInteger(-1)).toBe(false);
+    expect(isPositiveInteger(-100)).toBe(false);
+  });
+
+  test('returns false for floating point numbers', () => {
+    expect(isPositiveInteger(1.1)).toBe(false);
+    expect(isPositiveInteger(-3.14)).toBe(false);
+  });
+
+  test('returns false for non-number values', () => {
+    expect(isPositiveInteger('5')).toBe(false);
+    expect(isPositiveInteger(null)).toBe(false);
+    expect(isPositiveInteger(undefined)).toBe(false);
+    expect(isPositiveInteger(NaN)).toBe(false);
+    expect(isPositiveInteger({})).toBe(false);
+    expect(isPositiveInteger([])).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Remove unused flatten option and add isPositiveInteger.

## Description

Refactor dividerLoop like below.

- Remove unused flatten option and move the defenition.
- Add `isPositiveInteger`

<!-- A detailed explanation of the changes, including why they are needed -->
