### PR TITLE
Extract `divideNumberString` to utils

### DIFF
--- a/src/core/divider-number-string.ts
+++ b/src/core/divider-number-string.ts
@@ -1,20 +1,14 @@
 import { isString } from '@/utils/is';
 import type { DividerOptions, DividerResult } from '@/core/types';
+import { divideNumberString } from '@/utils/divide';
 
 export function dividerNumberString<
   T extends string | string[],
   F extends boolean = false,
 >(input: T, options?: DividerOptions<F>): DividerResult<T, F> {
-  const regex = /\d+|\D+/g;
+  const result = isString(input)
+    ? divideNumberString(input)
+    : input.map(divideNumberString);
 
-  const divide = (str: string): string[] => {
-    return (str.match(regex) || []).filter(Boolean);
-  };
-
-  if (isString(input)) {
-    return divide(input) as DividerResult<T, F>;
-  }
-
-  const result: string[][] = input.map(divide);
   return (options?.flatten ? result.flat() : result) as DividerResult<T, F>;
 }

--- a/src/utils/divide.ts
+++ b/src/utils/divide.ts
@@ -1,0 +1,3 @@
+export function divideNumberString(str: string): string[] {
+  return (str.match(/\d+|\D+/g) || []).filter(Boolean);
+}

--- a/tests/utils/divide.test.ts
+++ b/tests/utils/divide.test.ts
@@ -1,0 +1,59 @@
+import { divideNumberString } from '../../src/utils/divide';
+
+describe('divideNumberString', () => {
+  describe('divides string with number', () => {
+    test('In the middle', () => {
+      expect(divideNumberString('abc123def')).toEqual(['abc', '123', 'def']);
+    });
+
+    test('At the start', () => {
+      expect(divideNumberString('123abc')).toEqual(['123', 'abc']);
+    });
+
+    test('At the end', () => {
+      expect(divideNumberString('abc123')).toEqual(['abc', '123']);
+    });
+
+    test('Multiple numeric groups in a single string', () => {
+      expect(divideNumberString('ab12cd34ef')).toEqual([
+        'ab',
+        '12',
+        'cd',
+        '34',
+        'ef',
+      ]);
+    });
+  });
+
+  test('handles string with only letters', () => {
+    expect(divideNumberString('abc')).toEqual(['abc']);
+  });
+
+  test('handles string with only numbers', () => {
+    expect(divideNumberString('123456')).toEqual(['123456']);
+  });
+
+  test('handles alternating letters and digits', () => {
+    expect(divideNumberString('a1b2c3')).toEqual([
+      'a',
+      '1',
+      'b',
+      '2',
+      'c',
+      '3',
+    ]);
+  });
+
+  test('handles empty string', () => {
+    expect(divideNumberString('')).toEqual([]);
+  });
+
+  test('handles symbols and mixed characters', () => {
+    expect(divideNumberString('abc123!@#456')).toEqual([
+      'abc',
+      '123',
+      '!@#',
+      '456',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Extract `divideNumberString` to utils

<!-- A brief summary of the changes -->

## Description

I refactor dividerNumberString as below

- Extract `divideNumberString` to utils
- Refactor `dividerNumberString` logic
- Add test for `divideNumberString`

<!-- A detailed explanation of the changes, including why they are needed -->
