### PR TITLE
Add `trim` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ const result3 = dividerNumberString(['abc123', '45z'], { flatten: true });
 | Option    | Type      | Default | Description                                                               |
 | --------- | --------- | ------- | ------------------------------------------------------------------------- |
 | `flatten` | `boolean` | `false` | If `true`, the resulting nested arrays are flattened into a single array. |
+| `trim`    | `boolean` | `false` | If `true`, trims whitespace from each divided segment.                    |
 
 ### `flatten` (default: `false`)
 
@@ -167,6 +168,19 @@ const result2 = divider(words, 2, { flatten: true });
 // ['he', 'llo', 'wo', 'rld']
 ```
 
+### `trim` (default: `false`)
+
+```ts
+const result = divider('  hello world  ', 7, { trim: true });
+// ['hello', 'world']
+
+const result2 = divider(['  a  ', ' b  c '], ' ', {
+  flatten: true,
+  trim: true,
+});
+// ['a', 'b', 'c']
+```
+
 ## 💡 Features
 
 ### 🧩 Flexible Division
@@ -174,7 +188,7 @@ const result2 = divider(words, 2, { flatten: true });
 - Supports both `index-based` and `string-based` division
 - Supports `multiple separators` (mixing indexes and characters)
 - Works with both `string` and `string[]` input
-- Optional `flatten` behavior to control nested results
+- Optional `flatten` and `trim` behaviors to control output format
 - Includes `dividerNumberString()` to separate digits and letters
 
 ### 🎯 Targeted Extraction

--- a/src/core/divider-loop.ts
+++ b/src/core/divider-loop.ts
@@ -1,5 +1,6 @@
 import { isString, isPositiveInteger } from '@/utils/is';
 import { generateIndexes } from '@/utils/chunk';
+import { applyDividerOptions } from '@/utils/option';
 import type { DividerOptions, DividerResult } from '@/core/types';
 import { divider } from '@/core/divider';
 
@@ -13,16 +14,14 @@ export function dividerLoop<T extends string | string[], F extends boolean>(
     return [];
   }
 
+  const applyChunking = (str: string) =>
+    divider(str, ...generateIndexes(str, size));
+
   if (isString(input)) {
-    const indexes = generateIndexes(input, size);
-    return divider(input, ...indexes) as DividerResult<T, F>;
+    const result = applyChunking(input);
+    return applyDividerOptions<T, F>(result, options ?? {});
   }
 
-  const result = input.map((item) => {
-    const indexes = generateIndexes(item, size);
-    return divider(item, ...indexes);
-  });
-
-  const flatten = options?.flatten ?? false;
-  return (flatten ? result.flat() : result) as DividerResult<T, F>;
+  const result = input.map(applyChunking);
+  return applyDividerOptions<T, F>(result, options ?? {});
 }

--- a/src/core/divider-number-string.ts
+++ b/src/core/divider-number-string.ts
@@ -1,6 +1,7 @@
 import { isString } from '@/utils/is';
 import type { DividerOptions, DividerResult } from '@/core/types';
 import { divideNumberString } from '@/utils/divide';
+import { applyDividerOptions } from '@/utils/option';
 
 export function dividerNumberString<
   T extends string | string[],
@@ -10,5 +11,5 @@ export function dividerNumberString<
     ? divideNumberString(input)
     : input.map(divideNumberString);
 
-  return (options?.flatten ? result.flat() : result) as DividerResult<T, F>;
+  return applyDividerOptions<T, F>(result, options ?? {});
 }

--- a/src/core/divider.ts
+++ b/src/core/divider.ts
@@ -4,6 +4,7 @@ import { isString, isEmptyArray, isValidInput } from '@/utils/is';
 import { ensureArray } from '@/utils/array';
 import { extractOptions } from '@/utils/options';
 import { classifySeparators } from '@/utils/separator';
+import { applyDividerOptions } from '@/utils/option';
 
 export function divider<T extends string | string[], F extends boolean>(
   input: T,
@@ -23,16 +24,12 @@ export function divider<T extends string | string[], F extends boolean>(
   const { cleanedArgs, options } = extractOptions(args);
   const { numSeparators, strSeparators } = classifySeparators(cleanedArgs);
 
-  if (isString(input)) {
-    return divideString(input, numSeparators, strSeparators) as DividerResult<
-      T,
-      F
-    >;
-  }
+  const applyDivision = (str: string) =>
+    divideString(str, numSeparators, strSeparators);
 
-  const result = input.map((item) =>
-    divideString(item, numSeparators, strSeparators)
-  );
+  const result = isString(input)
+    ? applyDivision(input)
+    : input.map(applyDivision);
 
-  return (options.flatten ? result.flat() : result) as DividerResult<T, F>;
+  return applyDividerOptions<T, F>(result, options);
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3,7 +3,9 @@ export type DividerResult<
   F extends boolean = false,
 > = T extends string ? string[] : F extends true ? string[] : string[][];
 
-export type DividerOptions<F extends boolean> = { flatten?: F };
+export type DividerOptions<F extends boolean> = Partial<
+  Record<'flatten' | 'trim', F>
+>;
 
 export type DividerSeparators = (number | string)[];
 

--- a/src/utils/is.ts
+++ b/src/utils/is.ts
@@ -19,3 +19,17 @@ export function isPositiveInteger(value: unknown): boolean {
 export function isValidInput(input: unknown): input is string | string[] {
   return isString(input) || (Array.isArray(input) && input.every(isString));
 }
+
+export function isStringArray(input: unknown): input is string[] {
+  return Array.isArray(input) && input.every(isString);
+}
+
+export function isNestedStringArray(input: unknown): input is string[][] {
+  return (
+    Array.isArray(input) &&
+    input.length > 0 &&
+    Array.isArray(input[0]) &&
+    input[0].length > 0 &&
+    isStringArray(input[0])
+  );
+}

--- a/src/utils/option.ts
+++ b/src/utils/option.ts
@@ -1,0 +1,34 @@
+import type { DividerOptions, DividerResult } from '@/core/types';
+import { isNestedStringArray } from '@/utils/is';
+
+/**
+ * Applies options like `trim` and `flatten` to the divided result.
+ *
+ * - If `trim` is true, trims all string segments.
+ * - If `flatten` is true, flattens the nested array.
+ */
+export function applyDividerOptions<
+  T extends string | string[],
+  F extends boolean,
+>(
+  result: string[] | string[][],
+  options: DividerOptions<F>
+): DividerResult<T, F> {
+  let output: string[] | string[][] = result;
+
+  if (options.trim) {
+    const trimPart = (s: string) => s.trim();
+
+    if (isNestedStringArray(result)) {
+      output = result.map((row) => row.map(trimPart).filter(Boolean));
+    } else {
+      output = result.map(trimPart).filter(Boolean);
+    }
+  }
+
+  if (options.flatten) {
+    output = output.flat();
+  }
+
+  return output as DividerResult<T, F>;
+}

--- a/tests/core/divider-loop.test.ts
+++ b/tests/core/divider-loop.test.ts
@@ -51,3 +51,44 @@ describe('dividerLoop with string[]', () => {
     expect(dividerLoop([], 2, { flatten: true })).toEqual([]);
   });
 });
+
+describe('dividerLoop with trim option', () => {
+  test('trims whitespace in string mode', () => {
+    expect(dividerLoop('  ab  cd ef  ', 2, { trim: true })).toEqual([
+      'ab',
+      'cd',
+      'e',
+      'f',
+    ]);
+  });
+
+  test('does not trim when trim is false (string)', () => {
+    expect(dividerLoop('  ab  cd ef  ', 2, { trim: false })).toEqual([
+      '  ',
+      'ab',
+      '  ',
+      'cd',
+      ' e',
+      'f ',
+      ' ',
+    ]);
+  });
+
+  test('trims whitespace in string[] mode with flatten', () => {
+    expect(
+      dividerLoop([' hello ', ' world '], 2, {
+        flatten: true,
+        trim: true,
+      })
+    ).toEqual(['h', 'el', 'lo', 'w', 'or', 'ld']);
+  });
+
+  test('does not trim when trim is false (string[] flatten)', () => {
+    expect(
+      dividerLoop(['  hello ', ' world  '], 2, {
+        flatten: true,
+        trim: false,
+      })
+    ).toEqual(['  ', 'he', 'll', 'o ', ' w', 'or', 'ld', '  ']);
+  });
+});

--- a/tests/core/divider-number-string.test.ts
+++ b/tests/core/divider-number-string.test.ts
@@ -41,3 +41,30 @@ describe('dividerNumberString with string[]', () => {
     ]);
   });
 });
+
+describe('dividerNumberString with trim option', () => {
+  test('trims each part in string mode', () => {
+    expect(dividerNumberString(' abc 123 ', { trim: true })).toEqual([
+      'abc',
+      '123',
+    ]);
+  });
+
+  test('trims and flattens with string[] input', () => {
+    expect(
+      dividerNumberString(['  a1 ', ' b2 '], { flatten: true, trim: true })
+    ).toEqual(['a', '1', 'b', '2']);
+  });
+
+  test('preserves empty parts if trim is false', () => {
+    expect(
+      dividerNumberString([' a1 ', ' b2 '], { flatten: true, trim: false })
+    ).toEqual([' a', '1', ' ', ' b', '2', ' ']);
+  });
+
+  test('removes empty strings after trim', () => {
+    expect(dividerNumberString(['   '], { flatten: true, trim: true })).toEqual(
+      []
+    );
+  });
+});

--- a/tests/divider.test.ts
+++ b/tests/divider.test.ts
@@ -169,3 +169,35 @@ describe('divider with string[]', () => {
     expect(divider(['hello'], '😃')).toEqual([['hello']]);
   });
 });
+
+describe('divider with trim option', () => {
+  test('trims whitespace in string mode', () => {
+    expect(divider('  a  b   c  ', ' ', { trim: true })).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+  });
+
+  test('trims whitespace in string[] mode', () => {
+    expect(
+      divider(['  abc  ', ' de f '], ' ', { flatten: true, trim: true })
+    ).toEqual(['abc', 'de', 'f']);
+  });
+
+  test('does not trim when trim is false (string[])', () => {
+    expect(
+      divider(['  abc  ', ' de f '], ' ', { flatten: true, trim: false })
+    ).toEqual(['abc', 'de', 'f']);
+  });
+
+  test('works with flatten + trim', () => {
+    expect(
+      divider([' hello ', ' world  '], 2, { flatten: true, trim: true })
+    ).toEqual(['h', 'ello', 'w', 'orld']);
+  });
+
+  test('handles edge case with only spaces', () => {
+    expect(divider('   ', ' ', { trim: true })).toEqual([]);
+  });
+});

--- a/tests/utils/is.test.ts
+++ b/tests/utils/is.test.ts
@@ -3,6 +3,8 @@ import {
   isEmptyArray,
   isPositiveInteger,
   isValidInput,
+  isStringArray,
+  isNestedStringArray,
 } from '../../src/utils/is';
 
 describe('isOptions', () => {
@@ -49,26 +51,26 @@ describe('isEmptyArray', () => {
 });
 
 describe('isPositiveInteger', () => {
-  test('returns true for positive integers', () => {
+  test('true for positive integers', () => {
     expect(isPositiveInteger(1)).toBe(true);
     expect(isPositiveInteger(100)).toBe(true);
   });
 
-  test('returns false for zero', () => {
+  test('false for zero', () => {
     expect(isPositiveInteger(0)).toBe(false);
   });
 
-  test('returns false for negative integers', () => {
+  test('false for negative integers', () => {
     expect(isPositiveInteger(-1)).toBe(false);
     expect(isPositiveInteger(-100)).toBe(false);
   });
 
-  test('returns false for floating point numbers', () => {
+  test('false for floating point numbers', () => {
     expect(isPositiveInteger(1.1)).toBe(false);
     expect(isPositiveInteger(-3.14)).toBe(false);
   });
 
-  test('returns false for non-number values', () => {
+  test('false for non-number values', () => {
     expect(isPositiveInteger('5')).toBe(false);
     expect(isPositiveInteger(null)).toBe(false);
     expect(isPositiveInteger(undefined)).toBe(false);
@@ -79,35 +81,96 @@ describe('isPositiveInteger', () => {
 });
 
 describe('isValidInput', () => {
-  test('returns true for string', () => {
+  test('true for string', () => {
     expect(isValidInput('hello')).toBe(true);
   });
 
-  test('returns true for string[]', () => {
+  test('true for string[]', () => {
     expect(isValidInput(['hello', 'world'])).toBe(true);
   });
 
-  test('returns false for number', () => {
+  test('false for number', () => {
     expect(isValidInput(123)).toBe(false);
   });
 
-  test('returns false for boolean', () => {
+  test('false for boolean', () => {
     expect(isValidInput(true)).toBe(false);
   });
 
-  test('returns false for null', () => {
+  test('false for null', () => {
     expect(isValidInput(null)).toBe(false);
   });
 
-  test('returns false for undefined', () => {
+  test('false for undefined', () => {
     expect(isValidInput(undefined)).toBe(false);
   });
 
-  test('returns false for object', () => {
+  test('false for object', () => {
     expect(isValidInput({ key: 'value' })).toBe(false);
   });
 
-  test('returns false for array of non-strings', () => {
+  test('false for array of non-strings', () => {
     expect(isValidInput([1, 2, 3])).toBe(false);
+  });
+});
+
+describe('isStringArray', () => {
+  test('true for array of strings', () => {
+    expect(isStringArray(['a', 'b', 'c'])).toBe(true);
+  });
+
+  test('false for array with non-string elements', () => {
+    expect(isStringArray(['a', 1, 'b'])).toBe(false);
+    expect(isStringArray([1, 2, 3])).toBe(false);
+  });
+
+  test('false for non-array input', () => {
+    expect(isStringArray('abc')).toBe(false);
+    expect(isStringArray(null)).toBe(false);
+    expect(isStringArray(undefined)).toBe(false);
+    expect(isStringArray({})).toBe(false);
+  });
+
+  test('true for empty array (assumes string[])', () => {
+    expect(isStringArray([])).toBe(true);
+  });
+});
+
+describe('isNestedStringArray', () => {
+  test('true for array of string arrays', () => {
+    expect(
+      isNestedStringArray([
+        ['a', 'b'],
+        ['c', 'd'],
+      ])
+    ).toBe(true);
+  });
+
+  test('false for mixed-type inner arrays', () => {
+    expect(
+      isNestedStringArray([
+        ['a', 1],
+        ['c', 'd'],
+      ])
+    ).toBe(false);
+  });
+
+  test('false for flat string array', () => {
+    expect(isNestedStringArray(['a', 'b', 'c'])).toBe(false);
+  });
+
+  test('false for empty array', () => {
+    expect(isNestedStringArray([])).toBe(false);
+  });
+
+  test('false for empty inner arrays', () => {
+    expect(isNestedStringArray([[]])).toBe(false);
+  });
+
+  test('false for non-array input', () => {
+    expect(isNestedStringArray('abc')).toBe(false);
+    expect(isNestedStringArray(null)).toBe(false);
+    expect(isNestedStringArray(undefined)).toBe(false);
+    expect(isNestedStringArray({})).toBe(false);
   });
 });

--- a/tests/utils/option.test.ts
+++ b/tests/utils/option.test.ts
@@ -1,0 +1,42 @@
+import { applyDividerOptions } from '../../src/utils/option';
+
+describe('applyDividerOptions', () => {
+  test('trim only', () => {
+    const result = [
+      ['  a ', ' b'],
+      ['c ', ' d '],
+    ];
+    const options = { trim: true } as const;
+    expect(applyDividerOptions(result, options)).toEqual([
+      ['a', 'b'],
+      ['c', 'd'],
+    ]);
+  });
+
+  test('flatten only', () => {
+    const result = [
+      ['a', 'b'],
+      ['c', 'd'],
+    ];
+    const options = { flatten: true } as const;
+    expect(applyDividerOptions(result, options)).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  test('both trim and flatten', () => {
+    const result = [
+      [' a ', ' b'],
+      ['c ', 'd'],
+    ];
+    const options = { trim: true, flatten: true } as const;
+    expect(applyDividerOptions(result, options)).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  test('neither', () => {
+    const result = [
+      ['a', 'b'],
+      ['c', 'd'],
+    ];
+    const options = {} as const;
+    expect(applyDividerOptions(result, options)).toEqual(result);
+  });
+});


### PR DESCRIPTION
## Summary

Add `trim` option for divider

<!-- A brief summary of the changes -->

## Description

`trim` option allow user to eliminate whitespace from each divided segment.

This option can be used `divider` / `dividerLoop` / `dividerNumberString`,

<!-- A detailed explanation of the changes, including why they are needed -->
