### PR TITLE
Eliminate unnecessary condition from applyDividerOptions

### DIFF
--- a/src/utils/option.ts
+++ b/src/utils/option.ts
@@ -26,7 +26,7 @@ export function applyDividerOptions<
 
   // Then, apply flattening if needed
   if (options.flatten) {
-    output = isNestedStringArray(output) ? output.flat() : output;
+    output = output.flat();
   }
 
   return output as DividerResult<T, F>;

--- a/src/utils/option.ts
+++ b/src/utils/option.ts
@@ -14,20 +14,19 @@ export function applyDividerOptions<
   result: string[] | string[][],
   options: DividerOptions<F>
 ): DividerResult<T, F> {
-  let output: string[] | string[][] = result;
+  let output = result;
 
+  // First, apply trimming if needed
   if (options.trim) {
-    const trimPart = (s: string) => s.trim();
-
-    if (isNestedStringArray(result)) {
-      output = result.map((row) => row.map(trimPart).filter(Boolean));
-    } else {
-      output = result.map(trimPart).filter(Boolean);
-    }
+    const trim = (s: string) => s.trim();
+    output = isNestedStringArray(output)
+      ? output.map((row) => row.map(trim).filter(Boolean))
+      : output.map(trim).filter(Boolean);
   }
 
+  // Then, apply flattening if needed
   if (options.flatten) {
-    output = output.flat();
+    output = isNestedStringArray(output) ? output.flat() : output;
   }
 
   return output as DividerResult<T, F>;


### PR DESCRIPTION
## Summary

Eliminate unnecessary condition from applyDividerOptions

<!-- A brief summary of the changes -->

## Description

Simplify applyDividerOptions to improve readability and safety.

<!-- A detailed explanation of the changes, including why they are needed -->
