### PR TITLE
Add startOffset option to dividerLoop

### DIFF
--- a/src/core/divider-loop.ts
+++ b/src/core/divider-loop.ts
@@ -1,13 +1,13 @@
 import { isString, isPositiveInteger } from '@/utils/is';
 import { generateIndexes } from '@/utils/chunk';
 import { applyDividerOptions } from '@/utils/option';
-import type { DividerOptions, DividerResult } from '@/types';
+import type { DividerLoopOptions, DividerResult } from '@/types';
 import { divider } from '@/core/divider';
 
 export function dividerLoop<T extends string | string[]>(
   input: T,
   size: number,
-  options?: DividerOptions
+  options?: DividerLoopOptions
 ): DividerResult<T> {
   if (!isPositiveInteger(size)) {
     console.warn('dividerLoop: chunk size must be a positive number');
@@ -15,7 +15,7 @@ export function dividerLoop<T extends string | string[]>(
   }
 
   const applyChunking = (str: string) =>
-    divider(str, ...generateIndexes(str, size));
+    divider(str, ...generateIndexes(str, size, options?.startOffset ?? 0));
 
   if (isString(input)) {
     const result = applyChunking(input);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,10 @@ export type DividerResult<T extends string | string[]> = T extends string
 
 export type DividerOptions = Partial<Record<DividerOptionKey, boolean>>;
 
+export type DividerLoopOptions = DividerOptions & {
+  startOffset?: number;
+};
+
 export type DividerSeparators = (number | string)[];
 
 export type DividerArgs =

--- a/src/utils/chunk.ts
+++ b/src/utils/chunk.ts
@@ -1,3 +1,5 @@
+import { isPositiveInteger } from '@/utils/is';
+
 /**
  * Generates an array of index positions to divide a string into chunks.
  *
@@ -19,6 +21,11 @@ export function generateIndexes(
   size: number,
   startOffset = 0
 ): number[] {
+  if (!isPositiveInteger(size)) {
+    console.warn('generateIndexes: size must be a positive integer');
+    return [];
+  }
+
   const result: number[] = [];
   for (let i = startOffset + size; i < str.length; i += size) {
     result.push(i);

--- a/src/utils/chunk.ts
+++ b/src/utils/chunk.ts
@@ -1,7 +1,27 @@
-export function generateIndexes(text: string, size: number): number[] {
-  const indexes: number[] = [];
-  for (let i = size; i < text.length; i += size) {
-    indexes.push(i);
+/**
+ * Generates an array of index positions to divide a string into chunks.
+ *
+ * This function calculates split points by repeatedly adding the given `size`
+ * starting from the specified `startOffset`. These split points can be used
+ * with the `divider()` function to chunk a string.
+ *
+ * @param str - The target string to be divided
+ * @param size - The chunk size (must be a positive integer)
+ * @param startOffset - Optional starting index offset (default: 0)
+ * @returns An array of index positions where the string should be split
+ *
+ * @example
+ * generateIndexes('abcdefg', 2)       // → [2, 4, 6]
+ * generateIndexes('abcdefg', 3, 1)    // → [4]
+ */
+export function generateIndexes(
+  str: string,
+  size: number,
+  startOffset = 0
+): number[] {
+  const result: number[] = [];
+  for (let i = startOffset + size; i < str.length; i += size) {
+    result.push(i);
   }
-  return indexes;
+  return result;
 }

--- a/tests/core/divider-loop.test.ts
+++ b/tests/core/divider-loop.test.ts
@@ -10,6 +10,21 @@ describe('dividerLoop with string', () => {
     expect(dividerLoop('abcdefghij', 3)).toEqual(['abc', 'def', 'ghi', 'j']);
   });
 
+  describe('with startOffset option', () => {
+    test('applies startOffset correctly', () => {
+      expect(dividerLoop('abcdefgh', 2, { startOffset: 1 })).toEqual([
+        'abc',
+        'de',
+        'fg',
+        'h',
+      ]);
+    });
+
+    test('empty result if startOffset too large', () => {
+      expect(dividerLoop('abc', 2, { startOffset: 10 })).toEqual(['abc']);
+    });
+  });
+
   test('handles empty string', () => {
     expect(dividerLoop('', 3)).toEqual(['']);
   });
@@ -40,6 +55,25 @@ describe('dividerLoop with string[]', () => {
       'kl',
       'mn',
     ]);
+  });
+
+  describe('with startOffset option', () => {
+    test('applies startOffset correctly', () => {
+      expect(dividerLoop(['abcdef', 'ghijkl'], 2, { startOffset: 1 })).toEqual([
+        ['abc', 'de', 'f'],
+        ['ghi', 'jk', 'l'],
+      ]);
+    });
+
+    test('works with startOffset + flatten + trim', () => {
+      expect(
+        dividerLoop(['  hello', 'world  '], 2, {
+          startOffset: 1,
+          flatten: true,
+          trim: true,
+        })
+      ).toEqual(['h', 'el', 'lo', 'wor', 'ld']);
+    });
   });
 
   test('handles invalid size', () => {

--- a/tests/core/divider-loop.test.ts
+++ b/tests/core/divider-loop.test.ts
@@ -20,7 +20,7 @@ describe('dividerLoop with string', () => {
       ]);
     });
 
-    test('empty result if startOffset too large', () => {
+    test('returns original string if startOffset exceeds string length', () => {
       expect(dividerLoop('abc', 2, { startOffset: 10 })).toEqual(['abc']);
     });
   });

--- a/tests/utils/chunk.test.ts
+++ b/tests/utils/chunk.test.ts
@@ -1,24 +1,28 @@
 import { generateIndexes } from '../../src/utils/chunk';
 
 describe('generateIndexes', () => {
-  test('generates correct indexes for even division', () => {
-    expect(generateIndexes('abcdef', 2)).toEqual([2, 4]);
+  it('generates indexes with default startOffset (0)', () => {
+    expect(generateIndexes('abcdefg', 2)).toEqual([2, 4, 6]);
+    expect(generateIndexes('abcdef', 3)).toEqual([3]);
+    expect(generateIndexes('abcd', 5)).toEqual([]);
   });
 
-  test('generates correct indexes for uneven division', () => {
-    expect(generateIndexes('abcdefg', 3)).toEqual([3, 6]);
+  it('generates indexes with startOffset > 0', () => {
+    expect(generateIndexes('abcdefg', 2, 1)).toEqual([3, 5]);
+    expect(generateIndexes('abcdefg', 3, 1)).toEqual([4]);
+    expect(generateIndexes('abcdefg', 3, 2)).toEqual([5]);
   });
 
-  test('returns empty array when size is larger than length', () => {
-    expect(generateIndexes('abc', 10)).toEqual([]);
+  it('empty array if size is too large (startOffset considered)', () => {
+    expect(generateIndexes('abc', 3, 1)).toEqual([]);
   });
 
-  test('returns empty array for empty string', () => {
+  it('handles startOffset === string.length', () => {
+    expect(generateIndexes('abc', 2, 3)).toEqual([]);
+  });
+
+  it('handles empty string', () => {
     expect(generateIndexes('', 2)).toEqual([]);
-  });
-
-  test('generates all valid cut points for large string', () => {
-    const input = 'a'.repeat(20);
-    expect(generateIndexes(input, 5)).toEqual([5, 10, 15]);
+    expect(generateIndexes('', 2, 1)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Add startOffset option to `dividerLoop`

<!-- A brief summary of the changes -->

## Description

You can set `startOffset` to divide with dividerLoop like below.

```ts
 dividerLoop('abcdefg', 2)       // → ['ab', 'cd', 'ef', 'g']
 dividerLoop('abcdefg', 3, 1)    // → ['abcd', 'efg']
```

<!-- A detailed explanation of the changes, including why they are needed -->
