### PR TITLE
Add maxChunks option to dividerLoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ const result4 = dividerLoop(['  hello ', 'world  '], 2, {
   startOffset: 1,
 });
 // ['h', 'el', 'lo', 'wor', 'ld']
+
+// Limit the number of chunks using maxChunks
+const result5 = dividerLoop('abcdefghij', 3, { maxChunks: 2 });
+// ['abc', 'defghij']
 ```
 
 ### 📌 `dividerNumberString()` Usage
@@ -211,9 +215,10 @@ const result2 = divider(['  a  ', ' ', '  b'], ' ', {
 
 ## Special Options
 
-| Option        | Type     | Default | Description                                                              |
-| ------------- | -------- | ------- | ------------------------------------------------------------------------ |
-| `startOffset` | `number` | `0`     | Starting index offset when dividing into chunks (only for `dividerLoop`) |
+| Option        | Type     | Default | Description                                                                                             |
+| ------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `startOffset` | `number` | `0`     | Starting index offset when dividing into chunks (only for `dividerLoop`)                                |
+| `maxChunks`   | `number` | `∞`     | Maximum number of chunks allowed. Extra chunks are joined into the last chunk. (only for `dividerLoop`) |
 
 ## 💡 Features
 

--- a/src/core/divider-loop.ts
+++ b/src/core/divider-loop.ts
@@ -1,4 +1,4 @@
-import { isString, isPositiveInteger } from '@/utils/is';
+import { isString, isNumber, isPositiveInteger } from '@/utils/is';
 import { generateIndexes } from '@/utils/chunk';
 import { applyDividerOptions } from '@/utils/option';
 import type { DividerLoopOptions, DividerResult } from '@/types';
@@ -11,11 +11,25 @@ export function dividerLoop<T extends string | string[]>(
 ): DividerResult<T> {
   if (!isPositiveInteger(size)) {
     console.warn('dividerLoop: chunk size must be a positive number');
-    return [];
+    return [] as DividerResult<T>;
   }
 
-  const applyChunking = (str: string) =>
-    divider(str, ...generateIndexes(str, size, options?.startOffset ?? 0));
+  const { startOffset = 0, maxChunks } = options ?? {};
+
+  const applyChunking = (str: string) => {
+    let chunks = divider(str, ...generateIndexes(str, size, startOffset));
+
+    const shouldTruncateChunks =
+      isNumber(maxChunks) && maxChunks > 0 && chunks.length > maxChunks;
+
+    if (shouldTruncateChunks) {
+      const head = chunks.slice(0, maxChunks - 1);
+      const tail = chunks.slice(maxChunks - 1).join('');
+      chunks = [...head, tail];
+    }
+
+    return chunks;
+  };
 
   if (isString(input)) {
     const result = applyChunking(input);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,7 @@ export type DividerOptions = Partial<Record<DividerOptionKey, boolean>>;
 
 export type DividerLoopOptions = DividerOptions & {
   startOffset?: number;
+  maxChunks?: number;
 };
 
 export type DividerSeparators = (number | string)[];

--- a/tests/core/divider-loop.test.ts
+++ b/tests/core/divider-loop.test.ts
@@ -25,6 +25,27 @@ describe('dividerLoop with string', () => {
     });
   });
 
+  describe('with maxChunks option', () => {
+    test('limits chunks to 2 for a string input', () => {
+      expect(dividerLoop('abcdefghij', 3, { maxChunks: 2 })).toEqual([
+        'abc',
+        'defghij',
+      ]);
+    });
+
+    test('does not alter result when chunk count is below maxChunks', () => {
+      expect(dividerLoop('abcde', 2, { maxChunks: 5 })).toEqual([
+        'ab',
+        'cd',
+        'e',
+      ]);
+    });
+
+    test('returns a single merged chunk when maxChunks is 1', () => {
+      expect(dividerLoop('abcdef', 2, { maxChunks: 1 })).toEqual(['abcdef']);
+    });
+  });
+
   test('handles empty string', () => {
     expect(dividerLoop('', 3)).toEqual(['']);
   });
@@ -73,6 +94,28 @@ describe('dividerLoop with string[]', () => {
           trim: true,
         })
       ).toEqual(['h', 'el', 'lo', 'wor', 'ld']);
+    });
+  });
+
+  describe('with maxChunks option', () => {
+    test('limits chunks to 2 for an array of strings', () => {
+      expect(
+        dividerLoop(['abcdefghij', 'klmnopqrst'], 3, {
+          maxChunks: 2,
+        })
+      ).toEqual([
+        ['abc', 'defghij'],
+        ['klm', 'nopqrst'],
+      ]);
+    });
+
+    test('flattens the result when flatten: true is used', () => {
+      expect(
+        dividerLoop(['abcdefghij', 'klmnopqrst'], 3, {
+          maxChunks: 2,
+          flatten: true,
+        })
+      ).toEqual(['abc', 'defghij', 'klm', 'nopqrst']);
     });
   });
 


### PR DESCRIPTION
## Summary

Add `maxChunks` option to `dividerLoop`

<!-- A brief summary of the changes -->

## Description

To handle loop count, add `maxChunks` option to `dividerLoop`.

For example:

```ts
dividerLoop('abcdefghij', 3, { maxChunks: 2 });
// ['abc', 'defghij']
```

<!-- A detailed explanation of the changes, including why they are needed -->
