### PR TITLE
Unify excludeEmpty with exclude option

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,20 +168,20 @@ const result3 = dividerNumberString(['abc123', '45z'], { flatten: true });
 
 ## 🎯 General Options
 
-| Option         | Type      | Default | Description                                                               |
-| -------------- | --------- | ------- | ------------------------------------------------------------------------- |
-| `flatten`      | `boolean` | `false` | If `true`, the resulting nested arrays are flattened into a single array. |
-| `trim`         | `boolean` | `false` | If `true`, trims whitespace from each divided segment.                    |
-| `excludeEmpty` | `boolean` | `false` | If `true`, removes empty strings or strings with only whitespace.         |
+| Option    | Type      | Default | Description                                                               |
+| --------- | --------- | ------- | ------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------- |
+| `flatten` | `boolean` | `false` | If `true`, the resulting nested arrays are flattened into a single array. |
+| `trim`    | `boolean` | `false` | If `true`, trims whitespace from each divided segment.                    |
+| `exclude` | `'none'   | 'empty' | 'whitespace'`                                                             | `'none'` | Filter out specific segments: empty (`''`) or whitespace-only (`'   '`) |
 
 ### `flatten` (default: `false`)
 
 ```ts
 const words = ['hello', 'world'];
-const result1 = divider(words, 2);
+const result = divider(words, 2);
 // [['he', 'llo'], ['wo', 'rld']]
 
-const result2 = divider(words, 2, { flatten: true });
+const result = divider(words, 2, { flatten: true });
 // ['he', 'llo', 'wo', 'rld']
 ```
 
@@ -191,24 +191,30 @@ const result2 = divider(words, 2, { flatten: true });
 const result = divider('  hello world  ', 7, { trim: true });
 // ['hello', 'world']
 
-const result2 = divider(['  a  ', ' b  c '], ' ', {
+const result = divider(['  a  ', ' b  c '], ' ', {
   flatten: true,
   trim: true,
 });
 // ['a', 'b', 'c']
 ```
 
-### `excludeEmpty` (default: `false`)
+### `exclude` (default: `'none'`)
+
+Control how segments like empty strings (`''`) or whitespace-only strings (`'   '`) are handled.
 
 ```ts
-// Remove empty strings or strings with only spaces
-const result = divider('a, ,b', ',', { trim: true, excludeEmpty: true });
+// Remove truly empty strings
+const result1 = divider('a,,b', ',', { exclude: 'empty' });
 // ['a', 'b']
 
-const result2 = divider(['  a  ', ' ', '  b'], ' ', {
-  flatten: true,
+// Remove both empty and whitespace-only strings
+const result2 = divider('a, ,b', ',', { exclude: 'whitespace' });
+// ['a', 'b']
+
+// You can combine with `trim` for clearer results
+const result3 = divider('a, ,b', ',', {
   trim: true,
-  excludeEmpty: true,
+  exclude: 'whitespace',
 });
 // ['a', 'b']
 ```

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,12 +1,14 @@
-import { dividerOptionKeys } from '@/utils/constants';
-
-export type DividerOptionKey = (typeof dividerOptionKeys)[number];
+export type DividerExcludeMode = 'none' | 'empty' | 'whitespace';
 
 export type DividerResult<T extends string | string[]> = T extends string
   ? string[]
   : string[][];
 
-export type DividerOptions = Partial<Record<DividerOptionKey, boolean>>;
+export type DividerOptions = {
+  flatten?: boolean;
+  trim?: boolean;
+  exclude?: DividerExcludeMode;
+};
 
 export type DividerLoopOptions = DividerOptions & {
   startOffset?: number;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,1 +1,1 @@
-export const dividerOptionKeys = ['flatten', 'trim', 'excludeEmpty'] as const;
+export const dividerOptionKeys = ['flatten', 'trim'] as const;

--- a/src/utils/exclude-predicate.ts
+++ b/src/utils/exclude-predicate.ts
@@ -1,0 +1,11 @@
+import type { DividerExcludeMode } from '@/types';
+import { isEmptyString, isWhitespaceOnly } from '@/utils/is';
+
+export const excludePredicateMap: Record<
+  DividerExcludeMode,
+  (s: string) => boolean
+> = {
+  none: () => true,
+  empty: (s) => !isEmptyString(s),
+  whitespace: (s) => !isWhitespaceOnly(s),
+};

--- a/src/utils/is.ts
+++ b/src/utils/is.ts
@@ -1,5 +1,4 @@
-import { DividerOptions } from '@/types';
-import { dividerOptionKeys } from '@/utils/constants';
+import type { DividerOptions, DividerExcludeMode } from '@/types';
 
 export function isString(arg: unknown): arg is string {
   return typeof arg === 'string';
@@ -11,7 +10,8 @@ export function isNumber(arg: unknown): arg is number {
 
 export function isOptions(arg: unknown): arg is DividerOptions {
   if (typeof arg !== 'object' || arg === null) return false;
-  return dividerOptionKeys.some((key) => key in arg);
+
+  return 'flatten' in arg || 'trim' in arg || 'exclude' in arg;
 }
 
 export function isEmptyArray<T>(input: T[]): boolean {
@@ -42,4 +42,12 @@ export function isNestedStringArray(input: unknown): input is string[][] {
 
 export function isWhitespaceOnly(s: string) {
   return s.trim() === '';
+}
+
+export function isEmptyString(s: string): boolean {
+  return s === '';
+}
+
+export function isNoneMode(mode: unknown): mode is 'none' {
+  return mode === 'none';
 }

--- a/tests/divider.test.ts
+++ b/tests/divider.test.ts
@@ -32,13 +32,40 @@ describe('divider with string', () => {
     expect(divider('hello world', ' ', 3)).toEqual(['hel', 'lo', 'world']);
   });
 
-  test('flat option (default is false)', () => {
-    expect(divider('hello', 2, { flatten: true })).toEqual(['he', 'llo']);
-    expect(divider('hello', 2, { flatten: false })).toEqual(['he', 'llo']);
-  });
+  describe('options test', () => {
+    test('flat option (default is false)', () => {
+      expect(divider('hello', 2, { flatten: true })).toEqual(['he', 'llo']);
+      expect(divider('hello', 2, { flatten: false })).toEqual(['he', 'llo']);
+    });
 
-  it('excludes empty strings if excludeEmpty is true', () => {
-    expect(divider('a, ,b', ',', { excludeEmpty: true })).toEqual(['a', 'b']);
+    test('trims whitespace in string mode', () => {
+      expect(divider('  a  b   c  ', ' ', { trim: true })).toEqual([
+        'a',
+        'b',
+        'c',
+      ]);
+    });
+
+    test('handles edge case with only spaces', () => {
+      expect(divider('   ', ' ', { trim: true })).toEqual([]);
+    });
+
+    test('excludes empty strings', () => {
+      expect(divider('a, ,b', ',', { exclude: 'none' })).toEqual([
+        'a',
+        ' ',
+        'b',
+      ]);
+      expect(divider('a, ,b', ',', { exclude: 'empty' })).toEqual([
+        'a',
+        ' ',
+        'b',
+      ]);
+      expect(divider('a, ,b', ',', { exclude: 'whitespace' })).toEqual([
+        'a',
+        'b',
+      ]);
+    });
   });
 
   test('empty separators', () => {
@@ -131,36 +158,65 @@ describe('divider with string[]', () => {
     ]);
   });
 
-  test('flat option (default is false)', () => {
-    expect(divider(['hello', 'world'], 2, { flatten: true })).toEqual([
-      'he',
-      'llo',
-      'wo',
-      'rld',
-    ]);
-    expect(divider(['hello', 'world'], 'l', { flatten: true })).toEqual([
-      'he',
-      'o',
-      'wor',
-      'd',
-    ]);
-    expect(
-      divider(['hello', 'new world'], ' ', 'o', { flatten: true })
-    ).toEqual(['hell', 'new', 'w', 'rld']);
-    expect(
-      divider(['hello world', 'new world'], 2, 'o', { flatten: true })
-    ).toEqual(['he', 'll', ' w', 'rld', 'ne', 'w w', 'rld']);
-    expect(divider(['hello', 'world'], 2, { flatten: false })).toEqual([
-      ['he', 'llo'],
-      ['wo', 'rld'],
-    ]);
-  });
+  describe('options test', () => {
+    test('flat option (default is false)', () => {
+      expect(divider(['hello', 'world'], 2, { flatten: true })).toEqual([
+        'he',
+        'llo',
+        'wo',
+        'rld',
+      ]);
+      expect(divider(['hello', 'world'], 'l', { flatten: true })).toEqual([
+        'he',
+        'o',
+        'wor',
+        'd',
+      ]);
+      expect(
+        divider(['hello', 'new world'], ' ', 'o', { flatten: true })
+      ).toEqual(['hell', 'new', 'w', 'rld']);
+      expect(
+        divider(['hello world', 'new world'], 2, 'o', { flatten: true })
+      ).toEqual(['he', 'll', ' w', 'rld', 'ne', 'w w', 'rld']);
+      expect(divider(['hello', 'world'], 2, { flatten: false })).toEqual([
+        ['he', 'llo'],
+        ['wo', 'rld'],
+      ]);
+    });
 
-  it('excludes empty strings if excludeEmpty is true', () => {
-    expect(divider(['a', ', ,', 'b'], ',', { excludeEmpty: true })).toEqual([
-      ['a'],
-      ['b'],
-    ]);
+    test('trims whitespace in string[] mode', () => {
+      expect(
+        divider(['  abc  ', ' de f '], ' ', { flatten: true, trim: true })
+      ).toEqual(['abc', 'de', 'f']);
+    });
+
+    test('does not trim when trim is false (string[])', () => {
+      expect(
+        divider(['  abc  ', ' de f '], ' ', { flatten: true, trim: false })
+      ).toEqual(['abc', 'de', 'f']);
+    });
+
+    test('works with flatten + trim', () => {
+      expect(
+        divider([' hello ', ' world  '], 2, { flatten: true, trim: true })
+      ).toEqual(['h', 'ello', 'w', 'orld']);
+    });
+
+    test('excludes empty strings if excludeEmpty is true', () => {
+      expect(divider(['a', ', ,', 'b'], ',', { exclude: 'none' })).toEqual([
+        ['a'],
+        [' '],
+        ['b'],
+      ]);
+      expect(divider(['a', ', ,', 'b'], ',', { exclude: 'empty' })).toEqual([
+        ['a'],
+        [' '],
+        ['b'],
+      ]);
+      expect(
+        divider(['a', ', ,', 'b'], ',', { exclude: 'whitespace' })
+      ).toEqual([['a'], ['b']]);
+    });
   });
 
   test('empty separators', () => {
@@ -178,37 +234,5 @@ describe('divider with string[]', () => {
     expect(divider(['hello'], 5)).toEqual([['hello']]);
     expect(divider(['hello'], 10)).toEqual([['hello']]);
     expect(divider(['hello'], '😃')).toEqual([['hello']]);
-  });
-});
-
-describe('divider with trim option', () => {
-  test('trims whitespace in string mode', () => {
-    expect(divider('  a  b   c  ', ' ', { trim: true })).toEqual([
-      'a',
-      'b',
-      'c',
-    ]);
-  });
-
-  test('trims whitespace in string[] mode', () => {
-    expect(
-      divider(['  abc  ', ' de f '], ' ', { flatten: true, trim: true })
-    ).toEqual(['abc', 'de', 'f']);
-  });
-
-  test('does not trim when trim is false (string[])', () => {
-    expect(
-      divider(['  abc  ', ' de f '], ' ', { flatten: true, trim: false })
-    ).toEqual(['abc', 'de', 'f']);
-  });
-
-  test('works with flatten + trim', () => {
-    expect(
-      divider([' hello ', ' world  '], 2, { flatten: true, trim: true })
-    ).toEqual(['h', 'ello', 'w', 'orld']);
-  });
-
-  test('handles edge case with only spaces', () => {
-    expect(divider('   ', ' ', { trim: true })).toEqual([]);
   });
 });

--- a/tests/utils/chunk.test.ts
+++ b/tests/utils/chunk.test.ts
@@ -1,27 +1,27 @@
 import { generateIndexes } from '../../src/utils/chunk';
 
 describe('generateIndexes', () => {
-  it('generates indexes with default startOffset (0)', () => {
+  test('generates indexes with default startOffset (0)', () => {
     expect(generateIndexes('abcdefg', 2)).toEqual([2, 4, 6]);
     expect(generateIndexes('abcdef', 3)).toEqual([3]);
     expect(generateIndexes('abcd', 5)).toEqual([]);
   });
 
-  it('generates indexes with startOffset > 0', () => {
+  test('generates indexes with startOffset > 0', () => {
     expect(generateIndexes('abcdefg', 2, 1)).toEqual([3, 5]);
     expect(generateIndexes('abcdefg', 3, 1)).toEqual([4]);
     expect(generateIndexes('abcdefg', 3, 2)).toEqual([5]);
   });
 
-  it('empty array if size is too large (startOffset considered)', () => {
+  test('empty array if size is too large (startOffset considered)', () => {
     expect(generateIndexes('abc', 3, 1)).toEqual([]);
   });
 
-  it('handles startOffset === string.length', () => {
+  test('handles startOffset === string.length', () => {
     expect(generateIndexes('abc', 2, 3)).toEqual([]);
   });
 
-  it('handles empty string', () => {
+  test('handles empty string', () => {
     expect(generateIndexes('', 2)).toEqual([]);
     expect(generateIndexes('', 2, 1)).toEqual([]);
   });

--- a/tests/utils/is.test.ts
+++ b/tests/utils/is.test.ts
@@ -6,34 +6,36 @@ import {
   isStringArray,
   isNestedStringArray,
   isWhitespaceOnly,
+  isEmptyString,
+  isNoneMode,
 } from '../../src/utils/is';
 import type { DividerOptions } from '../../src/types';
 
 describe('isOptions', () => {
-  it('returns true for object with flatten', () => {
+  test('returns true for object with flatten', () => {
     const input: DividerOptions = { flatten: true };
     expect(isOptions(input)).toBe(true);
   });
 
-  it('returns true for object with trim', () => {
+  test('returns true for object with trim', () => {
     const input: DividerOptions = { trim: true };
     expect(isOptions(input)).toBe(true);
   });
 
-  it('returns true for object with excludeEmpty', () => {
-    const input: DividerOptions = { excludeEmpty: true };
+  test('returns true for object with excludeEmpty', () => {
+    const input: DividerOptions = { exclude: 'none' };
     expect(isOptions(input)).toBe(true);
   });
 
-  it('returns false for object with unrelated keys', () => {
+  test('returns false for object with unrelated keys', () => {
     expect(isOptions({ foo: 'bar' })).toBe(false);
   });
 
-  it('returns false for null', () => {
+  test('returns false for null', () => {
     expect(isOptions(null)).toBe(false);
   });
 
-  it('returns false for non-object values', () => {
+  test('returns false for non-object values', () => {
     expect(isOptions('string')).toBe(false);
     expect(isOptions(123)).toBe(false);
     expect(isOptions(true)).toBe(false);
@@ -186,23 +188,54 @@ describe('isNestedStringArray', () => {
 });
 
 describe('isWhitespaceOnly', () => {
-  it('true for an empty string', () => {
+  test('true for an empty string', () => {
     expect(isWhitespaceOnly('')).toBe(true);
   });
 
-  it('true for a string with only spaces', () => {
+  test('true for a string with only spaces', () => {
     expect(isWhitespaceOnly('   ')).toBe(true);
   });
 
-  it('true for a string with tabs and newlines only', () => {
+  test('true for a string with tabs and newlines only', () => {
     expect(isWhitespaceOnly('\t\n\r')).toBe(true);
   });
 
-  it('false for a non-empty string', () => {
+  test('false for a non-empty string', () => {
     expect(isWhitespaceOnly('a')).toBe(false);
   });
 
-  it('false for a string with spaces and characters', () => {
+  test('false for a string with spaces and characters', () => {
     expect(isWhitespaceOnly('  a  ')).toBe(false);
+  });
+});
+
+describe('isEmptyString', () => {
+  test('true for an empty string', () => {
+    expect(isEmptyString('')).toBe(true);
+  });
+
+  test('false for a non-empty string', () => {
+    expect(isEmptyString(' ')).toBe(false);
+    expect(isEmptyString('abc')).toBe(false);
+  });
+});
+
+describe('isNoneMode', () => {
+  test('true for "none"', () => {
+    expect(isNoneMode('none')).toBe(true);
+  });
+
+  test('false for other strings', () => {
+    expect(isNoneMode('empty')).toBe(false);
+    expect(isNoneMode('whitespace')).toBe(false);
+    expect(isNoneMode('')).toBe(false);
+  });
+
+  test('false for non-string types', () => {
+    expect(isNoneMode(undefined)).toBe(false);
+    expect(isNoneMode(null)).toBe(false);
+    expect(isNoneMode(0)).toBe(false);
+    expect(isNoneMode({})).toBe(false);
+    expect(isNoneMode([])).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Unify excludeEmpty with exclude option

<!-- A brief summary of the changes -->

## Description

Now, excludeEmpty option name guesses us that it eliminates all white space. But it does not eliminate because empty does not equal to whitespace.

I try to add new option, however adding option makes more complexity.

So, I make exclude option that choises mode of 'none', 'empty' and 'whitespace'.
<!-- A detailed explanation of the changes, including why they are needed -->
