### PR TITLE
Fix throw error and add tests

### DIFF
--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,6 +1,18 @@
 import type { DividerResult } from '@/types';
 import { isString } from '@/utils/is';
 
+/**
+ * Ensures that the input is returned as a string array.
+ *
+ * - If the input is a single string, it returns an array containing that string.
+ * - If the input is already a string array, it is returned as-is.
+ *
+ * This utility is helpful for normalizing input types when both `string` and `string[]`
+ * are supported.
+ *
+ * @param input - A string or array of strings
+ * @returns A normalized string array
+ */
 export function ensureStringArray<T extends string | string[]>(
   input: T
 ): DividerResult<T> {

--- a/src/utils/divide.ts
+++ b/src/utils/divide.ts
@@ -1,3 +1,15 @@
+/**
+ * Splits a string into an array of numeric and non-numeric segments.
+ *
+ * For example:
+ * `'abc123def456'` → `['abc', '123', 'def', '456']`
+ *
+ * Uses a regular expression to match sequences of digits (`\d+`)
+ * and sequences of non-digits (`\D+`) and returns them in order.
+ *
+ * @param str - The input string to divide
+ * @returns An array of segmented strings
+ */
 export function divideNumberString(str: string): string[] {
   return (str.match(/\d+|\D+/g) || []).filter(Boolean);
 }

--- a/src/utils/exclude-predicate.ts
+++ b/src/utils/exclude-predicate.ts
@@ -1,6 +1,17 @@
 import type { DividerExcludeMode } from '@/types';
 import { isEmptyString, isWhitespaceOnly } from '@/utils/is';
 
+/**
+ * A mapping of `exclude` modes to their corresponding filter predicates.
+ *
+ * - `'none'`: Accepts all strings (no filtering)
+ * - `'empty'`: Filters out empty strings (`""`)
+ * - `'whitespace'`: Filters out strings that contain only whitespace characters
+ *   (e.g. `"   "`, `"\n"`, `"\t"`)
+ *
+ * Typically used with `Array.prototype.filter()` to remove undesired items
+ * from divided results.
+ */
 export const excludePredicateMap: Record<
   DividerExcludeMode,
   (s: string) => boolean

--- a/src/utils/is.ts
+++ b/src/utils/is.ts
@@ -1,35 +1,60 @@
 import type { DividerOptions, DividerExcludeMode } from '@/types';
 
+/**
+ * Checks whether the given argument is a string.
+ */
 export function isString(arg: unknown): arg is string {
   return typeof arg === 'string';
 }
 
+/**
+ * Checks whether the given argument is a number.
+ */
 export function isNumber(arg: unknown): arg is number {
   return typeof arg === 'number';
 }
 
+/**
+ * Checks whether the given argument is a valid DividerOptions object.
+ * It must be a non-null object and contain at least one of the known option keys.
+ */
 export function isOptions(arg: unknown): arg is DividerOptions {
   if (typeof arg !== 'object' || arg === null) return false;
 
   return 'flatten' in arg || 'trim' in arg || 'exclude' in arg;
 }
 
+/**
+ * Checks whether the given array is empty.
+ */
 export function isEmptyArray<T>(input: T[]): boolean {
   return Array.isArray(input) && input.length === 0;
 }
 
+/**
+ * Checks whether the given value is a positive integer.
+ */
 export function isPositiveInteger(value: unknown): boolean {
   return Number.isInteger(value) && (value as number) > 0;
 }
 
+/**
+ * Checks whether the input is a string or an array of strings.
+ */
 export function isValidInput(input: unknown): input is string | string[] {
   return isString(input) || (Array.isArray(input) && input.every(isString));
 }
 
+/**
+ * Checks whether the input is an array of strings.
+ */
 export function isStringArray(input: unknown): input is string[] {
   return Array.isArray(input) && input.every(isString);
 }
 
+/**
+ * Checks whether the input is a non-empty, nested array of strings.
+ */
 export function isNestedStringArray(input: unknown): input is string[][] {
   return (
     Array.isArray(input) &&
@@ -40,14 +65,23 @@ export function isNestedStringArray(input: unknown): input is string[][] {
   );
 }
 
-export function isWhitespaceOnly(s: string) {
+/**
+ * Checks whether the given string contains only whitespace characters.
+ */
+export function isWhitespaceOnly(s: string): boolean {
   return s.trim() === '';
 }
 
+/**
+ * Checks whether the given string is empty.
+ */
 export function isEmptyString(s: string): boolean {
   return s === '';
 }
 
+/**
+ * Checks whether the given value is exactly the string 'none'.
+ */
 export function isNoneMode(mode: unknown): mode is 'none' {
   return mode === 'none';
 }

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -1,8 +1,20 @@
-import { isEmptyArray } from '@/utils/is';
+import { isEmptyArray, isNumber } from '@/utils/is';
 import { getRegex } from '@/utils/regex';
 import { sliceByIndexes } from '@/utils/slice';
 import { sortAscending } from '@/utils/sort';
 
+/**
+ * Divides a string using both numeric index positions and string delimiters.
+ *
+ * - If no separators are provided, returns the input string as a single-element array.
+ * - First, splits the string at given numeric index positions.
+ * - Then, further splits each resulting segment using the provided string delimiters (as regex).
+ *
+ * @param input - The input string to be divided.
+ * @param numSeparators - An array of numeric index positions to slice the string at.
+ * @param strSeparators - An array of string delimiters to further split the result.
+ * @returns An array of divided string segments.
+ */
 export function divideString(
   input: string,
   numSeparators: number[],
@@ -10,6 +22,10 @@ export function divideString(
 ): string[] {
   if (isEmptyArray(numSeparators) && isEmptyArray(strSeparators)) {
     return [input];
+  }
+
+  if (!Array.isArray(numSeparators) || !numSeparators.every(isNumber)) {
+    throw new Error('Invalid numeric separators');
   }
 
   // Precompile regex for string separators

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -2,6 +2,17 @@ import { isEmptyArray } from '@/utils/is';
 
 const regexCache = new Map<string, RegExp>();
 
+/**
+ * Generates a global RegExp to match any of the provided string separators.
+ *
+ * - Returns `null` if the input array is empty.
+ * - Uses a simple in-memory cache (`regexCache`) to avoid recompiling the same pattern.
+ * - Escapes each separator string to safely include special regex characters.
+ * - Compiled pattern is in the form `[a|b|c]` using a character class.
+ *
+ * @param separators - Array of strings to use as delimiters.
+ * @returns A global RegExp to match any of the delimiters, or `null` if input is empty.
+ */
 export function getRegex(separators: string[]): RegExp | null {
   if (isEmptyArray(separators)) return null;
 

--- a/src/utils/separator.ts
+++ b/src/utils/separator.ts
@@ -1,5 +1,18 @@
 import { isString, isNumber } from '@/utils/is';
 
+/**
+ * Classifies a mixed array of strings and numbers into separate arrays.
+ *
+ * Useful when variadic arguments (e.g., separators) may include both
+ * numeric index positions and string delimiters.
+ *
+ * @example
+ * classifySeparators([2, '-', 4, ','])
+ * // => { numSeparators: [2, 4], strSeparators: ['-', ','] }
+ *
+ * @param args - An array containing strings and/or numbers
+ * @returns An object with `numSeparators` and `strSeparators` arrays
+ */
 export function classifySeparators(args: (string | number)[]) {
   return args.reduce(
     (acc, arg) => {

--- a/src/utils/slice.ts
+++ b/src/utils/slice.ts
@@ -1,5 +1,19 @@
 import { isEmptyArray } from '@/utils/is';
 
+/**
+ * Slices a string into segments based on an array of index positions.
+ *
+ * Each index defines a cutting point. The string is sliced from the current
+ * start position up to each index. Invalid or overlapping indexes are ignored.
+ *
+ * @example
+ * sliceByIndexes('hello world', [2, 5])
+ * // => ['he', 'llo', ' world']
+ *
+ * @param input - The input string to slice.
+ * @param indexes - An array of index positions to slice at. Must be in ascending order.
+ * @returns An array of string segments.
+ */
 export function sliceByIndexes(input: string, indexes: number[]): string[] {
   if (isEmptyArray(indexes)) return [input];
 

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -1,3 +1,16 @@
+/**
+ * Returns a new array of numbers sorted in ascending order.
+ *
+ * This function creates a shallow copy of the input array to avoid
+ * mutating the original array.
+ *
+ * @example
+ * sortAscending([3, 1, 2])
+ * // => [1, 2, 3]
+ *
+ * @param numbers - The array of numbers to sort.
+ * @returns A new array sorted in ascending numerical order.
+ */
 export function sortAscending(numbers: number[]): number[] {
   return [...numbers].sort((a, b) => a - b);
 }

--- a/tests/utils/exclude-predicate.test.ts
+++ b/tests/utils/exclude-predicate.test.ts
@@ -1,0 +1,37 @@
+import { excludePredicateMap } from '../../src/utils/exclude-predicate';
+
+describe('excludePredicateMap', () => {
+  const allInputs = ['hello', '', '   ', '\n', '\t', 'world'];
+
+  test('mode: none - returns true for all inputs', () => {
+    const predicate = excludePredicateMap.none;
+    allInputs.forEach((input) => {
+      expect(predicate(input)).toBe(true);
+    });
+  });
+
+  test('mode: empty - filters out only empty strings', () => {
+    const predicate = excludePredicateMap.empty;
+
+    expect(predicate('')).toBe(false);
+    expect(predicate(' ')).toBe(true);
+    expect(predicate('hello')).toBe(true);
+    expect(predicate('\n')).toBe(true);
+  });
+
+  test('mode: whitespace - filters out empty and whitespace-only strings', () => {
+    const predicate = excludePredicateMap.whitespace;
+
+    expect(predicate('')).toBe(false);
+    expect(predicate('   ')).toBe(false);
+    expect(predicate('\n')).toBe(false);
+    expect(predicate('\t')).toBe(false);
+    expect(predicate('hello')).toBe(true);
+  });
+
+  test('integration: filter with mode=whitespace', () => {
+    const input = ['hello', '', ' ', 'world', '\n'];
+    const result = input.filter(excludePredicateMap.whitespace);
+    expect(result).toEqual(['hello', 'world']);
+  });
+});

--- a/tests/utils/parser.test.ts
+++ b/tests/utils/parser.test.ts
@@ -37,4 +37,18 @@ describe('divideString', () => {
   test('handles consecutive string separators correctly', () => {
     expect(divideString('hello--world', [], ['-'])).toEqual(['hello', 'world']);
   });
+
+  test('throws an error if numSeparators contains non-number values', () => {
+    expect(() =>
+      // @ts-expect-error intentional misuse
+      divideString('hello', ['not-a-number'], [])
+    ).toThrow('Invalid numeric separators');
+  });
+
+  test('throws an error if numSeparators is not an array', () => {
+    expect(() =>
+      // @ts-expect-error intentional misuse
+      divideString('hello', 'not-an-array', [])
+    ).toThrow('Invalid numeric separators');
+  });
 });


### PR DESCRIPTION
## Summary

Fix throw error and add tests

<!-- A brief summary of the changes -->

## Description

When coming numSeparators as invalid numeric separators, it may break after logic so catch and throw error.

In addition, add tests and comments.

<!-- A detailed explanation of the changes, including why they are needed -->
