### PR TITLE
ci: add lint and test checks to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Lint
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm test
+
       - name: Build package
         run: pnpm build
 


### PR DESCRIPTION
This pull request enhances the release workflow by incorporating both linting and testing steps directly into the `release.yml` pipeline.

While we already have dedicated workflows (`lint.yml`, `test.yml`) for these checks, this addition acts as a final safety net during the release phase, ensuring only well-tested and clean code gets deployed.

## ✅ Changes
- Added `npm run lint` and `npm test` steps to `release.yml`
- Reinforces code quality and test reliability at the point of release

## 📌 Why?
Even if earlier CI steps are skipped or fail silently, this ensures the release process does not proceed without passing lint and tests.