### PR TITLE
feat: csv divider preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,32 +175,12 @@ const result3 = dividerNumberString(['abc123', '45z'], { flatten: true });
 
 Some common use cases are wrapped as presets for convenience.
 
-#### `emailDivider()`
+| Preset name  | Description                                              |
+| ------------ | -------------------------------------------------------- |
+| emailDivider | Split email into [local-part, domain] (by '@')           |
+| csvDivider   | Split comma-separated strings, with quoted field support |
 
-Split an email address into its local and domain parts.
-
-```ts
-import { emailDivider } from '@nyaomaru/divider';
-
-const result = emailDivider('user@example.com');
-// ['user', 'example.com']
-```
-
-You can also split the domain part into subdomain and TLD by enabling the splitTLD option:
-
-```ts
-const result = emailDivider('user@mail.example.co.uk', { splitTLD: true });
-// ['user', 'mail', 'example', 'co', 'uk']
-```
-
-Trim whitespace from both parts if needed:
-
-```ts
-const result = emailDivider('  user@example.com  ', { trim: true });
-// ['user', 'example.com']
-```
-
-🛎 If multiple @ symbols are found, all segments are returned and a warning is logged.
+[Presets detail](src/presets/README.md)
 
 ## 🎯 General Options
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -42,3 +42,13 @@ export const PERFORMANCE_CONSTANTS = {
  * Separator character used for cache key concatenation.
  */
 export const CACHE_KEY_SEPARATOR = '\x00';
+
+/**
+ * A constant representing a single whitespace character.
+ */
+export const WHITE_SPACE = ' ';
+
+/**
+ * Tab character constant used for indentation and formatting.
+ */
+export const TAB = '\t';

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,5 @@ export { dividerLast } from '@/core/divider-last';
 export { dividerLoop } from '@/core/divider-loop';
 export { dividerNumberString } from '@/core/divider-number-string';
 export { emailDivider } from '@/presets/email-divider';
+export { csvDivider } from '@/presets/csv-divider';
 export * from './types';

--- a/src/presets/README.md
+++ b/src/presets/README.md
@@ -1,0 +1,106 @@
+### 📌 Presets
+
+Some common use cases are wrapped as presets for convenience.
+
+#### `emailDivider()`
+
+Split an email address into its local and domain parts.
+
+```ts
+import { emailDivider } from '@nyaomaru/divider';
+
+const result = emailDivider('user@example.com');
+// ['user', 'example.com']
+```
+
+You can also split the domain part into subdomain and TLD by enabling the splitTLD option:
+
+```ts
+const result = emailDivider('user@mail.example.co.uk', { splitTLD: true });
+// ['user', 'mail', 'example', 'co', 'uk']
+```
+
+Trim whitespace from both parts if needed:
+
+```ts
+const result = emailDivider('  user@example.com  ', { trim: true });
+// ['user', 'example.com']
+```
+
+🛎 If multiple @ symbols are found, all segments are returned and a warning is logged.
+
+#### `csvDivider()`
+
+Splits a CSV line into an array of fields, handling quoted values correctly.
+Internally uses a quoted-aware splitter built on top of `divider`.
+
+```ts
+import { csvDivider } from '@nyaomaru/divider';
+
+const result = csvDivider('a,b,c');
+// ['a', 'b', 'c']
+```
+
+Multiple quoted fields:
+
+```ts
+const result = csvDivider('"a, b", "c, d", e');
+// ['a, b', ' c, d', ' e']
+```
+
+Escaped quotes ("" → " restoration):
+
+```ts
+const result = csvDivider('"a, ""quoted""",b');
+// ['a, "quoted"', 'b']
+```
+
+Empty values and trailing separators are preserved:
+
+```ts
+const result = csvDivider('a,,c,');
+// ['a', '', 'c', '']
+```
+
+Without trimming (outer spaces are preserved):
+
+```ts
+const result = csvDivider('  a , " b " , c ', { trim: false });
+// ['  a ', '  b  ', ' c ']
+```
+
+Custom quote character:
+
+```ts
+const result = csvDivider("'a,b',c", { quoteChar: "'" });
+// ['a,b', 'c']
+```
+
+Custom delimiter:
+
+```ts
+const result = csvDivider('"a;b";c;"";d;', { delimiter: ';' });
+// ['a;b', 'c', '', 'd', '']
+```
+
+Lenient parsing for unclosed quotes:
+
+```ts
+const result = csvDivider('"a,b');
+// ['a,b']
+```
+
+Empty input returns a single empty field:
+
+```ts
+const result = csvDivider('');
+// ['']
+```
+
+- Options
+  - `delimiter` (default: `','`)
+    - Character used to separate fields (one character only).
+  - `quoteChar` (default: `'"'`)
+    - Character used to wrap fields containing special characters (one character only).
+  - `trim` (default: `false`)
+    - If true, trims leading and trailing whitespace from field values after removing quotes.

--- a/src/presets/csv-divider.ts
+++ b/src/presets/csv-divider.ts
@@ -1,65 +1,86 @@
 import type { DividerStringResult } from '@/types';
 import type { CsvDividerOptions } from '@/types/preset';
-import { isEscapedQuote } from '@/utils/is';
-
-const ESCAPED_QUOTE_LENGTH = 2;
+import { divider } from '@/core/divider';
 
 /**
- * Divides a CSV string into fields, handling quoted values and optional trimming.
- *
- * - Handles escaped quotes like: "She said ""Hi"""
- * - Respects quoted commas: "a, b",c → ['a, b', 'c']
- * - Optional `trim` to remove surrounding whitespace
- * - Optional `quoteChar` (default: `"`), useful for custom CSV dialects
- *
- * @param input - The CSV-formatted string
- * @param options - Optional settings: trim whitespace, custom quote character
- * @returns An array of string segments
+ * Tokenize by delimiter using core `divider`, but fall back to native `split`
+ * if empty tokens (from consecutive/trailing delimiters) are lost.
  */
+function tokenizePreservingEmpties(input: string, delimiter: string): string[] {
+  const viaCore = divider(input, delimiter);
+  // If re-joining does not equal the original, empties were likely collapsed.
+  if (viaCore.join(delimiter) !== input) {
+    return input.split(delimiter); // preserves consecutive/trailing empties
+  }
+  return viaCore;
+}
+
+function countUnescapedQuotes(s: string, q: string) {
+  const doubled = q + q;
+  const noEsc = s.split(doubled).join('');
+  let cnt = 0;
+  for (let i = 0; i < noEsc.length; i++) if (noEsc[i] === q) cnt++;
+  return cnt;
+}
+
+/**
+ * Remove outer quotes while keeping surrounding spaces; restore escaped quotes.
+ */
+function unquotePreservingOuterSpaces(s: string, q: string, lenient = true) {
+  const doubled = q + q;
+  const isSpace = (ch: string) => ch === ' ' || ch === '\t';
+  let l = 0,
+    r = s.length - 1;
+  while (l <= r && isSpace(s[l])) l++;
+  while (r >= l && isSpace(s[r])) r--;
+
+  if (l <= r) {
+    const startsQ = s[l] === q;
+    const endsQ = s[r] === q;
+    if (startsQ && endsQ && r > l) {
+      s = s.slice(0, l) + s.slice(l + 1, r) + s.slice(r + 1);
+    } else if (lenient && startsQ) {
+      s = s.slice(0, l) + s.slice(l + 1);
+      let rr = s.length - 1;
+      while (rr >= 0 && isSpace(s[rr])) rr--;
+      if (rr >= 0 && s[rr] === q) s = s.slice(0, rr) + s.slice(rr + 1);
+    }
+  }
+  return s.split(doubled).join(q);
+}
+
 export function csvDivider(
   input: string,
   options: CsvDividerOptions = {}
 ): DividerStringResult {
-  const { trim = false, quoteChar = '"' } = options;
-  const result: string[] = [];
+  const { trim = false, quoteChar = '"', delimiter = ',' } = options;
 
-  if (input === '') {
-    return [''];
-  }
+  if (input === '') return [''];
 
+  // 1) Tokenize (preserving consecutive/trailing empties)
+  const tokens = tokenizePreservingEmpties(input, delimiter);
+
+  const out: string[] = [];
   let current = '';
   let inQuotes = false;
-  let i = 0;
 
-  const pushField = () => {
-    result.push(trim ? current.trim() : current);
+  const finalize = () => {
+    let field = unquotePreservingOuterSpaces(current, quoteChar, true);
+    if (trim) field = field.trim();
+    out.push(field);
     current = '';
   };
 
-  while (i < input.length) {
-    const char = input[i];
-    const nextChar = input[i + 1];
-
-    if (char === quoteChar) {
-      if (inQuotes && isEscapedQuote(char, nextChar, quoteChar)) {
-        current += quoteChar;
-        i += ESCAPED_QUOTE_LENGTH;
-      } else {
-        inQuotes = !inQuotes;
-        i++;
-      }
-    } else if (char === ',' && !inQuotes) {
-      pushField();
-      i++;
-    } else {
-      current += char;
-      i++;
-    }
+  // 2) Fold tokens; merge while inside quotes
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i];
+    current = current === '' ? t : current + delimiter + t;
+    inQuotes = countUnescapedQuotes(current, quoteChar) % 2 === 1;
+    if (!inQuotes) finalize();
   }
 
-  if (current || input.endsWith(',')) {
-    pushField();
-  }
+  // 3) Lenient finalize (unclosed quotes)
+  if (current !== '') finalize();
 
-  return result;
+  return out;
 }

--- a/src/presets/csv-divider.ts
+++ b/src/presets/csv-divider.ts
@@ -2,7 +2,16 @@ import type { DividerStringResult } from '@/types';
 import type { CsvDividerOptions } from '@/types/preset';
 import { quotedDivide } from '@/utils/quoted';
 
-/** CSV preset built on top of divider-powered quoted splitter. */
+/**
+ * Divides a CSV line into an array of fields, handling quoted values appropriately.
+ *
+ * @param line - The CSV line string to be divided into fields
+ * @param options - Configuration options for CSV parsing
+ * @param options.delimiter - The character used to separate fields (default: ',')
+ * @param options.quoteChar - The character used to quote fields containing delimiters or newlines (default: '"')
+ * @param options.trim - Whether to trim whitespace from field values (default: false)
+ * @returns A DividerStringResult containing the parsed CSV fields
+ */
 export function csvDivider(
   line: string,
   options: CsvDividerOptions = {}

--- a/src/presets/csv-divider.ts
+++ b/src/presets/csv-divider.ts
@@ -1,0 +1,56 @@
+import type { DividerStringResult } from '@/types';
+import type { CsvDividerOptions } from '@/types/preset';
+import { isEscapedQuote } from '@/utils/is';
+
+const ESCAPED_QUOTE_LENGTH = 2;
+
+/**
+ * Divides a CSV string into fields, handling quoted values and optional trimming.
+ *
+ * @param input - The CSV-formatted string
+ * @param options - Optional settings: trim whitespace, custom quote character
+ * @returns An array of string segments
+ */
+export function csvDivider(
+  input: string,
+  options: CsvDividerOptions = {}
+): DividerStringResult {
+  const { trim = false, quoteChar = '"' } = options;
+  const result: string[] = [];
+
+  let current = '';
+  let inQuotes = false;
+  let i = 0;
+
+  const pushField = () => {
+    result.push(trim ? current.trim() : current);
+    current = '';
+  };
+
+  while (i < input.length) {
+    const char = input[i];
+    const nextChar = input[i + 1];
+
+    if (char === quoteChar) {
+      if (inQuotes && isEscapedQuote(char, nextChar, quoteChar)) {
+        current += quoteChar;
+        i += ESCAPED_QUOTE_LENGTH;
+      } else {
+        inQuotes = !inQuotes;
+        i++;
+      }
+    } else if (char === ',' && !inQuotes) {
+      pushField();
+      i++;
+    } else {
+      current += char;
+      i++;
+    }
+  }
+
+  if (current || input.endsWith(',')) {
+    pushField();
+  }
+
+  return result;
+}

--- a/src/presets/csv-divider.ts
+++ b/src/presets/csv-divider.ts
@@ -1,86 +1,17 @@
 import type { DividerStringResult } from '@/types';
 import type { CsvDividerOptions } from '@/types/preset';
-import { divider } from '@/core/divider';
+import { quotedSplit } from '@/utils/quoted';
 
-/**
- * Tokenize by delimiter using core `divider`, but fall back to native `split`
- * if empty tokens (from consecutive/trailing delimiters) are lost.
- */
-function tokenizePreservingEmpties(input: string, delimiter: string): string[] {
-  const viaCore = divider(input, delimiter);
-  // If re-joining does not equal the original, empties were likely collapsed.
-  if (viaCore.join(delimiter) !== input) {
-    return input.split(delimiter); // preserves consecutive/trailing empties
-  }
-  return viaCore;
-}
-
-function countUnescapedQuotes(s: string, q: string) {
-  const doubled = q + q;
-  const noEsc = s.split(doubled).join('');
-  let cnt = 0;
-  for (let i = 0; i < noEsc.length; i++) if (noEsc[i] === q) cnt++;
-  return cnt;
-}
-
-/**
- * Remove outer quotes while keeping surrounding spaces; restore escaped quotes.
- */
-function unquotePreservingOuterSpaces(s: string, q: string, lenient = true) {
-  const doubled = q + q;
-  const isSpace = (ch: string) => ch === ' ' || ch === '\t';
-  let l = 0,
-    r = s.length - 1;
-  while (l <= r && isSpace(s[l])) l++;
-  while (r >= l && isSpace(s[r])) r--;
-
-  if (l <= r) {
-    const startsQ = s[l] === q;
-    const endsQ = s[r] === q;
-    if (startsQ && endsQ && r > l) {
-      s = s.slice(0, l) + s.slice(l + 1, r) + s.slice(r + 1);
-    } else if (lenient && startsQ) {
-      s = s.slice(0, l) + s.slice(l + 1);
-      let rr = s.length - 1;
-      while (rr >= 0 && isSpace(s[rr])) rr--;
-      if (rr >= 0 && s[rr] === q) s = s.slice(0, rr) + s.slice(rr + 1);
-    }
-  }
-  return s.split(doubled).join(q);
-}
-
+/** CSV preset built on top of divider-powered quoted splitter. */
 export function csvDivider(
-  input: string,
+  line: string,
   options: CsvDividerOptions = {}
 ): DividerStringResult {
-  const { trim = false, quoteChar = '"', delimiter = ',' } = options;
-
-  if (input === '') return [''];
-
-  // 1) Tokenize (preserving consecutive/trailing empties)
-  const tokens = tokenizePreservingEmpties(input, delimiter);
-
-  const out: string[] = [];
-  let current = '';
-  let inQuotes = false;
-
-  const finalize = () => {
-    let field = unquotePreservingOuterSpaces(current, quoteChar, true);
-    if (trim) field = field.trim();
-    out.push(field);
-    current = '';
-  };
-
-  // 2) Fold tokens; merge while inside quotes
-  for (let i = 0; i < tokens.length; i++) {
-    const t = tokens[i];
-    current = current === '' ? t : current + delimiter + t;
-    inQuotes = countUnescapedQuotes(current, quoteChar) % 2 === 1;
-    if (!inQuotes) finalize();
-  }
-
-  // 3) Lenient finalize (unclosed quotes)
-  if (current !== '') finalize();
-
-  return out;
+  const { delimiter = ',', quoteChar = '"', trim = false } = options;
+  return quotedSplit(line, {
+    delimiter,
+    quote: quoteChar,
+    trim,
+    lenient: true,
+  });
 }

--- a/src/presets/csv-divider.ts
+++ b/src/presets/csv-divider.ts
@@ -1,6 +1,6 @@
 import type { DividerStringResult } from '@/types';
 import type { CsvDividerOptions } from '@/types/preset';
-import { quotedSplit } from '@/utils/quoted';
+import { quotedDivide } from '@/utils/quoted';
 
 /** CSV preset built on top of divider-powered quoted splitter. */
 export function csvDivider(
@@ -8,7 +8,7 @@ export function csvDivider(
   options: CsvDividerOptions = {}
 ): DividerStringResult {
   const { delimiter = ',', quoteChar = '"', trim = false } = options;
-  return quotedSplit(line, {
+  return quotedDivide(line, {
     delimiter,
     quote: quoteChar,
     trim,

--- a/src/presets/csv-divider.ts
+++ b/src/presets/csv-divider.ts
@@ -7,6 +7,11 @@ const ESCAPED_QUOTE_LENGTH = 2;
 /**
  * Divides a CSV string into fields, handling quoted values and optional trimming.
  *
+ * - Handles escaped quotes like: "She said ""Hi"""
+ * - Respects quoted commas: "a, b",c → ['a, b', 'c']
+ * - Optional `trim` to remove surrounding whitespace
+ * - Optional `quoteChar` (default: `"`), useful for custom CSV dialects
+ *
  * @param input - The CSV-formatted string
  * @param options - Optional settings: trim whitespace, custom quote character
  * @returns An array of string segments
@@ -17,6 +22,10 @@ export function csvDivider(
 ): DividerStringResult {
   const { trim = false, quoteChar = '"' } = options;
   const result: string[] = [];
+
+  if (input === '') {
+    return [''];
+  }
 
   let current = '';
   let inQuotes = false;

--- a/src/types/preset.ts
+++ b/src/types/preset.ts
@@ -6,4 +6,5 @@ export type EmailDividerOptions = Pick<DividerOptions, 'trim'> & {
 
 export type CsvDividerOptions = Pick<DividerOptions, 'trim'> & {
   quoteChar?: '"' | "'";
+  delimiter?: string;
 };

--- a/src/types/preset.ts
+++ b/src/types/preset.ts
@@ -1,0 +1,5 @@
+import type { DividerOptions } from '@/types';
+
+export type CsvDividerOptions = Pick<DividerOptions, 'trim'> & {
+  quoteChar?: '"' | "'";
+};

--- a/src/types/preset.ts
+++ b/src/types/preset.ts
@@ -5,6 +5,6 @@ export type EmailDividerOptions = Pick<DividerOptions, 'trim'> & {
 };
 
 export type CsvDividerOptions = Pick<DividerOptions, 'trim'> & {
-  quoteChar?: '"' | "'";
+  quoteChar?: string;
   delimiter?: string;
 };

--- a/src/utils/is.ts
+++ b/src/utils/is.ts
@@ -96,3 +96,17 @@ export function isNoneMode(
 ): mode is typeof DividerExcludeModes.NONE {
   return mode === DividerExcludeModes.NONE;
 }
+
+/**
+ * Checks if a character represents an escaped quote in a string.
+ *
+ * An escaped quote is identified when the current character matches the quote character
+ * and is immediately followed by the same quote character (e.g., "" in CSV or '' in SQL).
+ */
+export function isEscapedQuote(
+  char: string,
+  next: string,
+  quoteChar: string
+): boolean {
+  return char === quoteChar && next === quoteChar;
+}

--- a/src/utils/is.ts
+++ b/src/utils/is.ts
@@ -96,17 +96,3 @@ export function isNoneMode(
 ): mode is typeof DividerExcludeModes.NONE {
   return mode === DividerExcludeModes.NONE;
 }
-
-/**
- * Checks if a character represents an escaped quote in a string.
- *
- * An escaped quote is identified when the current character matches the quote character
- * and is immediately followed by the same quote character (e.g., "" in CSV or '' in SQL).
- */
-export function isEscapedQuote(
-  char: string,
-  next: string,
-  quoteChar: string
-): boolean {
-  return char === quoteChar && next === quoteChar;
-}

--- a/src/utils/quoted.ts
+++ b/src/utils/quoted.ts
@@ -1,0 +1,99 @@
+import { divider } from '@/core/divider';
+
+/** Split by `sep` while preserving consecutive/trailing empties. */
+export function splitPreserve(input: string, sep: string): string[] {
+  const viaCore = divider(input, sep);
+  return viaCore.join(sep) === input ? viaCore : input.split(sep);
+}
+
+/** Count quotes excluding escaped pairs (""). Assumes single-char `quote`. */
+export function countUnescaped(text: string, quote: string): number {
+  const pair = quote + quote;
+  let count = 0;
+  for (const chunk of splitPreserve(text, pair)) {
+    // occurrences of a single quote == splits - 1
+    count += splitPreserve(chunk, quote).length - 1;
+  }
+  return count;
+}
+
+/** Remove an outer quote pair (keep surrounding spaces) and restore "" -> ". */
+export function stripOuterQuotes(
+  text: string,
+  quote: string,
+  { lenient = true }: { lenient?: boolean } = {}
+): string {
+  const pair = quote + quote;
+  const isSpace = (c: string) => c === ' ' || c === '\t';
+
+  let left = 0,
+    right = text.length - 1;
+  while (left <= right && isSpace(text[left])) left++;
+  while (right >= left && isSpace(text[right])) right--;
+
+  if (left <= right) {
+    const starts = text[left] === quote;
+    const ends = text[right] === quote;
+    if (starts && ends && right > left) {
+      // Remove both quotes as a pair
+      text =
+        text.slice(0, left) +
+        text.slice(left + 1, right) +
+        text.slice(right + 1);
+    } else if (lenient && starts) {
+      // Remove only the starting quote (unclosed or mismatched)
+      text = text.slice(0, left) + text.slice(left + 1);
+      // Optionally remove a trailing quote (after spaces)
+      let r = text.length - 1;
+      while (r >= 0 && isSpace(text[r])) r--;
+      if (r >= 0 && text[r] === quote)
+        text = text.slice(0, r) + text.slice(r + 1);
+    }
+  }
+
+  return text.split(pair).join(quote);
+}
+
+/**
+ * Quoted-aware split built on top of `divider`.
+ * - Tokenize by delimiter (preserving empties)
+ * - Merge tokens while inside quotes
+ * - Remove outer quotes, restore escaped quotes, optionally trim
+ */
+export function quotedSplit(
+  line: string,
+  {
+    delimiter = ',',
+    quote = '"',
+    trim = false,
+    lenient = true,
+  }: {
+    delimiter?: string;
+    quote?: string;
+    trim?: boolean;
+    lenient?: boolean;
+  } = {}
+): string[] {
+  if (line === '') return [''];
+
+  const pieces = splitPreserve(line, delimiter);
+  const fields: string[] = [];
+  let buffer = '';
+  let insideQuotes = false;
+
+  const flush = () => {
+    let v = stripOuterQuotes(buffer, quote, { lenient });
+    if (trim) v = v.trim();
+    fields.push(v);
+    buffer = '';
+  };
+
+  for (const piece of pieces) {
+    buffer = buffer === '' ? piece : buffer + delimiter + piece;
+    insideQuotes = countUnescaped(buffer, quote) % 2 === 1;
+    if (!insideQuotes) flush();
+  }
+
+  if (buffer !== '') flush();
+  return fields;
+}

--- a/src/utils/quoted.ts
+++ b/src/utils/quoted.ts
@@ -3,6 +3,8 @@ import { WHITE_SPACE, TAB } from '@/constants';
 
 /** Divide by `separator` while preserving consecutive/trailing empties. */
 export function dividePreserve(input: string, separator: string): string[] {
+  if (input === '') return [''];
+
   const divided = divider(input, separator);
   return divided.join(separator) === input ? divided : input.split(separator);
 }
@@ -78,12 +80,12 @@ export function stripOuterQuotes(
 }
 
 /**
- * Quoted-aware split built on top of `divider`.
+ * Quoted-aware divide built on top of `divider`.
  * - Tokenize by delimiter (preserving empties)
  * - Merge tokens while inside quotes
  * - Remove outer quotes, restore escaped quotes, optionally trim
  */
-export function quotedSplit(
+export function quotedDivide(
   line: string,
   {
     delimiter = ',',

--- a/tests/presets/csv-divider.test.ts
+++ b/tests/presets/csv-divider.test.ts
@@ -72,4 +72,43 @@ describe('csvDivider', () => {
 
     expect(result).toEqual(['', 'a', '', 'b']);
   });
+  it('handles completely empty input', () => {
+    const input = '';
+
+    const result = csvDivider(input);
+
+    expect(result).toEqual(['']);
+  });
+
+  it('handles input with only commas', () => {
+    const input = ',,';
+
+    const result = csvDivider(input);
+
+    expect(result).toEqual(['', '', '']);
+  });
+
+  it('handles trailing quoted field with comma inside', () => {
+    const input = 'a,"b,c"';
+
+    const result = csvDivider(input);
+
+    expect(result).toEqual(['a', 'b,c']);
+  });
+
+  it('handles unclosed quote gracefully (lenient parsing)', () => {
+    const input = '"a,b';
+
+    const result = csvDivider(input);
+
+    expect(result).toEqual(['a,b']); // Still parses as one field
+  });
+
+  it('handles only a quoted escaped quote', () => {
+    const input = '"""","b"';
+
+    const result = csvDivider(input);
+
+    expect(result).toEqual(['"', 'b']);
+  });
 });

--- a/tests/presets/csv-divider.test.ts
+++ b/tests/presets/csv-divider.test.ts
@@ -1,0 +1,75 @@
+import { csvDivider } from '../../src/presets/csv-divider';
+
+describe('csvDivider', () => {
+  it('parses simple comma-separated values', () => {
+    const input = 'a,b,c';
+
+    const result = csvDivider(input);
+
+    expect(result).toEqual(['a', 'b', 'c']);
+  });
+
+  it('handles quoted field with comma', () => {
+    const input = '"a,b",c';
+
+    const result = csvDivider(input);
+
+    expect(result).toEqual(['a,b', 'c']);
+  });
+
+  it('handles multiple quoted fields with commas', () => {
+    const input = '"a, b", "c, d", e';
+
+    const result = csvDivider(input);
+
+    expect(result).toEqual(['a, b', ' c, d', ' e']);
+  });
+
+  it('handles escaped double quotes inside field', () => {
+    const input = '"a, ""quoted""",b';
+
+    const result = csvDivider(input);
+
+    expect(result).toEqual(['a, "quoted"', 'b']);
+  });
+
+  it('trims whitespace when option is enabled', () => {
+    const input = '  a , " b , c "  , d ';
+
+    const result = csvDivider(input, { trim: true });
+
+    expect(result).toEqual(['a', 'b , c', 'd']);
+  });
+
+  it('does not trim when option is disabled', () => {
+    const input = '  a , " b " , c ';
+
+    const result = csvDivider(input, { trim: false });
+
+    expect(result).toEqual(['  a ', '  b  ', ' c ']);
+  });
+
+  it('respects single quote as quoteChar option', () => {
+    const input = "'a,b',c";
+
+    const result = csvDivider(input, { quoteChar: "'" });
+
+    expect(result).toEqual(['a,b', 'c']);
+  });
+
+  it('parses empty values correctly', () => {
+    const input = 'a,,c,';
+
+    const result = csvDivider(input);
+
+    expect(result).toEqual(['a', '', 'c', '']);
+  });
+
+  it('handles quoted empty strings', () => {
+    const input = '"",a,"",b';
+
+    const result = csvDivider(input);
+
+    expect(result).toEqual(['', 'a', '', 'b']);
+  });
+});

--- a/tests/utils/quoted.test.ts
+++ b/tests/utils/quoted.test.ts
@@ -1,0 +1,147 @@
+import {
+  dividePreserve,
+  countUnescaped,
+  stripOuterQuotes,
+  quotedDivide,
+} from '../../src/utils/quoted';
+
+describe('dividePreserve', () => {
+  it('splits normally with single delimiter', () => {
+    expect(dividePreserve('a,b,c', ',')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('preserves consecutive empties', () => {
+    expect(dividePreserve('a,,c', ',')).toEqual(['a', '', 'c']);
+  });
+
+  it('preserves trailing empty token', () => {
+    expect(dividePreserve('a,b,', ',')).toEqual(['a', 'b', '']);
+  });
+
+  it('preserves leading empty token', () => {
+    expect(dividePreserve(',a,b', ',')).toEqual(['', 'a', 'b']);
+  });
+
+  it('returns single empty field for empty input', () => {
+    expect(dividePreserve('', ',')).toEqual(['']);
+  });
+});
+
+describe('countUnescaped', () => {
+  it('counts single quotes, ignoring escaped pairs', () => {
+    expect(countUnescaped('"', '"')).toBe(1);
+    expect(countUnescaped('""', '"')).toBe(0);
+    expect(countUnescaped('"""', '"')).toBe(1);
+    expect(countUnescaped('""""', '"')).toBe(0);
+  });
+
+  it('counts quotes across chunks split by escaped pairs', () => {
+    expect(countUnescaped('He said ""Hi""', '"')).toBe(0);
+    expect(countUnescaped('"a","b"', '"')).toBe(4);
+  });
+});
+
+describe('stripOuterQuotes', () => {
+  it('removes a matched outer quote pair and keeps surrounding spaces', () => {
+    expect(stripOuterQuotes(' "a" ', '"')).toBe(' a ');
+    expect(stripOuterQuotes('\t"abc"\t', '"')).toBe('\tabc\t');
+  });
+
+  it('restores escaped quotes inside', () => {
+    expect(stripOuterQuotes('"He said ""Hi"""', '"')).toBe('He said "Hi"');
+  });
+
+  it('returns original when not starting with a quote (except escape restore)', () => {
+    expect(stripOuterQuotes('no-quotes', '"')).toBe('no-quotes');
+  });
+
+  it('handles unclosed starting quote leniently (default)', () => {
+    expect(stripOuterQuotes('"abc', '"')).toBe('abc');
+    expect(stripOuterQuotes('  "abc  ', '"')).toBe('  abc  ');
+  });
+
+  it('does not strip when lenient=false and unclosed', () => {
+    expect(stripOuterQuotes('"abc', '"', { lenient: false })).toBe('"abc');
+  });
+
+  it('optionally removes trailing quote after spaces when only start is quoted', () => {
+    expect(stripOuterQuotes('"a"  ', '"')).toBe('a  ');
+  });
+});
+
+describe('quotedDivide', () => {
+  it('splits simple CSV', () => {
+    expect(quotedDivide('a,b,c')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('preserves empty values from consecutive/trailing delimiters', () => {
+    expect(quotedDivide('a,,c,')).toEqual(['a', '', 'c', '']);
+    expect(quotedDivide(',a,')).toEqual(['', 'a', '']);
+  });
+
+  it('handles a quoted field containing delimiter', () => {
+    expect(quotedDivide('"a,b",c')).toEqual(['a,b', 'c']);
+  });
+
+  it('handles multiple quoted fields with commas and spaces around', () => {
+    expect(quotedDivide('"a, b"," c, d"," e"')).toEqual([
+      'a, b',
+      ' c, d',
+      ' e',
+    ]);
+  });
+
+  it('handles escaped double quotes inside a field', () => {
+    expect(quotedDivide('"a, ""quoted""",b')).toEqual(['a, "quoted"', 'b']);
+  });
+
+  it('trims whitespace when option is enabled (after unquoting)', () => {
+    expect(quotedDivide('  "a" , " b , c " ,  "d"  ', { trim: true })).toEqual([
+      'a',
+      'b , c',
+      'd',
+    ]);
+  });
+
+  it('does not trim when option is disabled', () => {
+    expect(quotedDivide('  "a" , " b " ,  " c "  ', { trim: false })).toEqual([
+      '  a ',
+      '  b  ',
+      '   c   ',
+    ]);
+  });
+
+  it('respects single-quote as quote char', () => {
+    expect(quotedDivide("'a,b',c", { quote: "'" })).toEqual(['a,b', 'c']);
+  });
+
+  it('handles quoted empty strings and normal values', () => {
+    expect(quotedDivide('"",a,"",b')).toEqual(['', 'a', '', 'b']);
+  });
+
+  it('handles input with only delimiters', () => {
+    expect(quotedDivide(',,')).toEqual(['', '', '']);
+  });
+
+  it('handles trailing quoted field with delimiter inside', () => {
+    expect(quotedDivide('a,"b,c"')).toEqual(['a', 'b,c']);
+  });
+
+  it('handles unclosed quote gracefully (lenient)', () => {
+    expect(quotedDivide('"a,b')).toEqual(['a,b']);
+  });
+
+  it('supports custom delimiter', () => {
+    expect(quotedDivide('"a;b";c;"";d;', { delimiter: ';' })).toEqual([
+      'a;b',
+      'c',
+      '',
+      'd',
+      '',
+    ]);
+  });
+
+  it('returns single empty field for empty input', () => {
+    expect(quotedDivide('')).toEqual(['']);
+  });
+});


### PR DESCRIPTION
#208

## Summary

New feature: `csvDivider` preset for parsing comma-separated values with quoted field support.

## Description

This PR introduces a new preset function `csvDivider` that parses a CSV-formatted string into an array of values.

While the core `divider` function supports flexible splitting, `csvDivider` targets a very common real-world use case: handling CSV data with quoted fields.

### Features

- Respects quoted segments:
  - `"a,b",c` → ['a,b', 'c']
  - `"a, ""quoted""",c` → ['a, "quoted"', 'c']
- Trims values if the `trim` option is enabled
- Custom `quoteChar` supported (default: `"`; also supports `'`)
- Handles malformed or partial values gracefully

### Options

```ts
csvDivider(input: string, {
  trim?: boolean     // Trim whitespace from fields
  quoteChar?: string // Default: `"`, can be overridden to `'`
  delimiter?: string // Default: `,`, can be overridden to some string
})
