### PR TITLE
Add code of conduct document

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,45 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers of the **Divider** project pledge to make participation in our community welcoming, safe, and equitable for everyone.
+
+We are committed to fostering an environment that respects the dignity, rights, and contributions of all individuals—regardless of race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, religion or philosophy, national or social origin, socio-economic position, level of education, or any other status.
+
+Everyone who engages with this project in good faith is welcome.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Unacceptable behavior includes:
+
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others’ private information without explicit permission
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable behavior.
+
+## Scope
+
+This Code of Conduct applies to all **Divider** community spaces, including GitHub issues, pull requests, discussions, and any other platforms where the project is represented.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at:
+
+📧 **nyaonyao0725@gmail.com**
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/README.md
+++ b/README.md
@@ -265,3 +265,9 @@ We welcome contributions!
 Please read our [CONTRIBUTING.md](./CONTRIBUTING.md) guide before submitting a PR.
 
 Thank you for your contribution. 😺
+
+## 📚 Additional Documents
+
+- [DEVELOPER.md](./DEVELOPER.md) — Development setup and contributor guide
+- [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) — Community standards and conduct
+- [CHANGELOG.md](./CHANGELOG.md) — Version history and notable changes


### PR DESCRIPTION
Close #205

## Summary

Add code of conduct document

<!-- A brief summary of the changes -->

## Description

- Added a new `CODE_OF_CONDUCT.md` file based on Contributor Covenant v2.1
- Updated `README.md` to include links to:
  - `DEVELOPER.md`
  - `CODE_OF_CONDUCT.md`
  - `CHANGELOG.md`

<!-- A detailed explanation of the changes, including why they are needed -->
