### PR TITLE
Fix divider interface type

### DIFF
--- a/src/core/divider-first.ts
+++ b/src/core/divider-first.ts
@@ -1,6 +1,6 @@
 import { divider } from '@/core/divider';
 import { getFirstElement } from '@/utils/array';
-import type { DividerSeparators } from '@/types';
+import type { DividerInput, DividerSeparators } from '@/types';
 
 /**
  * Extracts the first segment after dividing the input using specified separators.
@@ -13,7 +13,7 @@ import type { DividerSeparators } from '@/types';
  * dividerFirst("abc123def", 3) // returns "abc"
  */
 export function dividerFirst(
-  input: string | string[],
+  input: DividerInput,
   ...args: DividerSeparators
 ): string {
   const result = divider(input, ...args, { flatten: true }) as string[];

--- a/src/core/divider-last.ts
+++ b/src/core/divider-last.ts
@@ -1,6 +1,6 @@
 import { divider } from '@/core/divider';
 import { getLastElement } from '@/utils/array';
-import type { DividerSeparators } from '@/types';
+import type { DividerInput, DividerSeparators } from '@/types';
 
 /**
  * Extracts the last segment after dividing the input using specified separators.
@@ -13,7 +13,7 @@ import type { DividerSeparators } from '@/types';
  * dividerLast("abc123def", 3) // returns "def"
  */
 export function dividerLast(
-  input: string | string[],
+  input: DividerInput,
   ...args: DividerSeparators
 ): string {
   const result = divider(input, ...args, { flatten: true }) as string[];

--- a/src/core/divider-loop.ts
+++ b/src/core/divider-loop.ts
@@ -1,7 +1,7 @@
 import { isString, isNumber, isPositiveInteger } from '@/utils/is';
 import { generateIndexes } from '@/utils/chunk';
 import { applyDividerOptions } from '@/utils/option';
-import type { DividerLoopOptions, DividerResult } from '@/types';
+import type { DividerInput, DividerLoopOptions, DividerResult } from '@/types';
 import { divider } from '@/core/divider';
 import { PERFORMANCE_CONSTANTS } from '@/constants';
 
@@ -82,7 +82,7 @@ function createChunksFromString(
  * dividerLoop("abcdef", 2) // returns ["ab", "cd", "ef"]
  * dividerLoop("abcdef", 2, { maxChunks: 2 }) // returns ["ab", "cdef"]
  */
-export function dividerLoop<T extends string | string[]>(
+export function dividerLoop<T extends DividerInput>(
   input: T,
   size: number,
   options?: DividerLoopOptions

--- a/src/core/divider-number-string.ts
+++ b/src/core/divider-number-string.ts
@@ -1,5 +1,5 @@
 import { isString } from '@/utils/is';
-import type { DividerOptions, DividerResult } from '@/types';
+import type { DividerInput, DividerOptions, DividerResult } from '@/types';
 import { divideNumberString } from '@/utils/divide';
 import { applyDividerOptions } from '@/utils/option';
 
@@ -16,7 +16,7 @@ import { applyDividerOptions } from '@/utils/option';
  * dividerNumberString("abc123def") // returns ["abc", "123", "def"]
  * dividerNumberString("test42") // returns ["test", "42"]
  */
-export function dividerNumberString<T extends string | string[]>(
+export function dividerNumberString<T extends DividerInput>(
   input: T,
   options?: DividerOptions
 ): DividerResult<T> {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,7 +5,7 @@ export type DividerExcludeMode =
 
 // Type guard for string input
 export type StringInput = string;
-export type StringArrayInput = string[];
+export type StringArrayInput = readonly string[];
 export type DividerInput = StringInput | StringArrayInput;
 
 // Result types with more specific naming

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -13,7 +13,7 @@ import { isString } from '@/utils/is';
  * @param input - A string or array of strings
  * @returns A normalized string array
  */
-export function ensureStringArray<T extends string | string[]>(
+export function ensureStringArray<T extends string | readonly string[]>(
   input: T
 ): DividerResult<T> {
   return (isString(input) ? [input] : input) as DividerResult<T>;
@@ -26,7 +26,7 @@ export function ensureStringArray<T extends string | string[]>(
  * @param fallback - The fallback value if array is empty (default: '')
  * @returns The first element or fallback value
  */
-export function getFirstElement<T>(array: T[], fallback: T): T {
+export function getFirstElement<T>(array: readonly T[], fallback: T): T {
   return array[0] ?? fallback;
 }
 
@@ -37,6 +37,6 @@ export function getFirstElement<T>(array: T[], fallback: T): T {
  * @param fallback - The fallback value if array is empty (default: '')
  * @returns The last element or fallback value
  */
-export function getLastElement<T>(array: T[], fallback: T): T {
+export function getLastElement<T>(array: readonly T[], fallback: T): T {
   return array.at(-1) ?? fallback;
 }

--- a/src/utils/option.ts
+++ b/src/utils/option.ts
@@ -57,7 +57,7 @@ export function extractOptions<F extends boolean>(
  * @param options - The `DividerOptions` that determine how to modify the result.
  * @returns The processed result after applying the options.
  */
-export function applyDividerOptions<T extends string | string[]>(
+export function applyDividerOptions<T extends string | readonly string[]>(
   result: string[] | string[][],
   options: DividerOptions
 ): DividerResult<T> {


### PR DESCRIPTION
## Summary

Fix divider interface type to use readonly

<!-- A brief summary of the changes -->

## Description

Readonly array type makes users relief to use divider.

<!-- A detailed explanation of the changes, including why they are needed -->
