### PR TITLE
chore: block installing packages published within 2 days

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,10 @@ We welcome any improvements, whether it's a feature, bugfix, test, or documentat
 pnpm install
 ```
 
+This repository uses pnpm's `minimumReleaseAge` safeguard. Dependency versions
+published less than 2 days ago are blocked during install to reduce supply-chain
+risk.
+
 To run tests locally:
 
 ```sh

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -15,8 +15,8 @@ pnpm install
 ```
 
 Note: the repo enforces pnpm's minimum package age policy. Installs will block
-dependency versions published within the last 2 days (`minimumReleaseAge:
-2880`) to reduce supply-chain risk.
+dependency versions published within the last 2 days (`minimumReleaseAge: 2880`)
+to reduce supply-chain risk.
 
 Using mise? It’s optional but comfy:
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -14,6 +14,10 @@ cd divider
 pnpm install
 ```
 
+Note: the repo enforces pnpm's minimum package age policy. Installs will block
+dependency versions published within the last 2 days (`minimumReleaseAge:
+2880`) to reduce supply-chain risk.
+
 Using mise? It’s optional but comfy:
 
 - Install mise (pick one):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
+# WHY: Delay dependency installs for newly published versions to reduce
+# exposure to compromised releases before the ecosystem has time to react.
+minimumReleaseAge: 2880
+
 overrides:
   js-yaml@<3.14.2: '>=3.14.2 <4.0.0'
   js-yaml@>=4.0.0 <4.1.1: '^4.1.1'


### PR DESCRIPTION
## Summary

Block installing packages published within 2 days.

<!-- A brief summary of the changes -->

## Description

Add a repo-level pnpm supply-chain safeguard by setting `minimumReleaseAge: 2880` in `pnpm-workspace.yaml`, which blocks installing package versions published less than 2 days ago. Update contributor and developer docs to explain the new install behavior and the rationale behind it.


<!-- A detailed explanation of the changes, including why they are needed -->
