### PR TITLE
refactor: extract quote whitespace predicate into shared utils

### DIFF
--- a/src/utils/is.ts
+++ b/src/utils/is.ts
@@ -117,11 +117,11 @@ export function isNestedStringArray(value: unknown): value is string[][] {
 }
 
 /**
- * Determines whether the provided character is a supported field whitespace.
+ * Determines whether the provided character is a space or tab.
  * @param value Character to inspect.
  * @returns True when the character is a space or tab.
  */
-export function isWhiteSpace(value: string): boolean {
+export function isSpaceOrTab(value: string): boolean {
   return value === WHITE_SPACE || value === TAB;
 }
 

--- a/src/utils/is.ts
+++ b/src/utils/is.ts
@@ -1,5 +1,10 @@
 import type { DividerOptions, DividerInput } from '@/types';
-import { DIVIDER_EXCLUDE_MODES, DIVIDER_OPTION_KEYS } from '@/constants';
+import {
+  DIVIDER_EXCLUDE_MODES,
+  DIVIDER_OPTION_KEYS,
+  TAB,
+  WHITE_SPACE,
+} from '@/constants';
 
 /**
  * Determines whether the provided value is a string.
@@ -109,6 +114,15 @@ export function isNestedStringArray(value: unknown): value is string[][] {
   // WHY: Divider outputs are trusted; checking only the first row avoids
   // a full scan while still distinguishing nested vs flat arrays.
   return Array.isArray(firstRow) && firstRow.every((item) => isString(item));
+}
+
+/**
+ * Determines whether the provided character is a supported field whitespace.
+ * @param value Character to inspect.
+ * @returns True when the character is a space or tab.
+ */
+export function isWhiteSpace(value: string): boolean {
+  return value === WHITE_SPACE || value === TAB;
 }
 
 /**

--- a/src/utils/strip-outer-quotes.ts
+++ b/src/utils/strip-outer-quotes.ts
@@ -1,11 +1,11 @@
-import { isWhiteSpace } from '@/utils/is';
+import { isSpaceOrTab } from '@/utils/is';
 
 const findNonSpaceBounds = (text: string) => {
   let left = 0;
   let right = text.length - 1;
 
-  while (left <= right && isWhiteSpace(text[left])) left++;
-  while (right >= left && isWhiteSpace(text[right])) right--;
+  while (left <= right && isSpaceOrTab(text[left])) left++;
+  while (right >= left && isSpaceOrTab(text[right])) right--;
 
   return { left, right };
 };
@@ -29,7 +29,7 @@ const stripTrailingQuote = (
 ) => {
   const quoteLength = quote.length;
   let lastNonSpaceIndex = text.length - 1;
-  while (lastNonSpaceIndex >= 0 && isWhiteSpace(text[lastNonSpaceIndex])) {
+  while (lastNonSpaceIndex >= 0 && isSpaceOrTab(text[lastNonSpaceIndex])) {
     lastNonSpaceIndex--;
   }
 

--- a/src/utils/strip-outer-quotes.ts
+++ b/src/utils/strip-outer-quotes.ts
@@ -1,14 +1,11 @@
-import { TAB, WHITE_SPACE } from '@/constants';
+import { isWhiteSpace } from '@/utils/is';
 
-const findNonSpaceBounds = (
-  text: string,
-  isWhitespace: (char: string) => boolean,
-) => {
+const findNonSpaceBounds = (text: string) => {
   let left = 0;
   let right = text.length - 1;
 
-  while (left <= right && isWhitespace(text[left])) left++;
-  while (right >= left && isWhitespace(text[right])) right--;
+  while (left <= right && isWhiteSpace(text[left])) left++;
+  while (right >= left && isWhiteSpace(text[right])) right--;
 
   return { left, right };
 };
@@ -29,11 +26,10 @@ const removeQuoteAt = (text: string, start: number, quote: string) =>
 const stripTrailingQuote = (
   text: string,
   quote: string,
-  isWhitespace: (char: string) => boolean,
 ) => {
   const quoteLength = quote.length;
   let lastNonSpaceIndex = text.length - 1;
-  while (lastNonSpaceIndex >= 0 && isWhitespace(text[lastNonSpaceIndex])) {
+  while (lastNonSpaceIndex >= 0 && isWhiteSpace(text[lastNonSpaceIndex])) {
     lastNonSpaceIndex--;
   }
 
@@ -52,11 +48,10 @@ const stripOuterQuotesRaw = (
   text: string,
   quote: string,
   lenient: boolean,
-  isWhitespace: (char: string) => boolean,
 ) => {
   if (quote.length === 0) return text;
 
-  const { left, right } = findNonSpaceBounds(text, isWhitespace);
+  const { left, right } = findNonSpaceBounds(text);
   if (left > right) return text;
   if (!text.startsWith(quote, left)) return text;
 
@@ -71,7 +66,7 @@ const stripOuterQuotesRaw = (
   if (!lenient) return text;
 
   const withoutLeading = removeQuoteAt(text, left, quote);
-  return stripTrailingQuote(withoutLeading, quote, isWhitespace);
+  return stripTrailingQuote(withoutLeading, quote);
 };
 
 /**
@@ -88,8 +83,7 @@ export function stripOuterQuotes(
   quoteChar: string,
   { lenient = true }: { lenient?: boolean } = {},
 ): string {
-  const isWhitespace = (char: string) => char === WHITE_SPACE || char === TAB;
-  const stripped = stripOuterQuotesRaw(text, quoteChar, lenient, isWhitespace);
+  const stripped = stripOuterQuotesRaw(text, quoteChar, lenient);
   if (quoteChar.length === 0) return stripped;
 
   const escapedPair = quoteChar + quoteChar;

--- a/tests/utils/is.test.ts
+++ b/tests/utils/is.test.ts
@@ -6,7 +6,7 @@ import {
   isStringArray,
   isStringOrNumber,
   isNestedStringArray,
-  isWhiteSpace,
+  isSpaceOrTab,
   isWhitespaceOnly,
   isEmptyString,
   isNoneMode,
@@ -233,21 +233,21 @@ describe('isWhitespaceOnly', () => {
   });
 });
 
-describe('isWhiteSpace', () => {
+describe('isSpaceOrTab', () => {
   test('true for a space character', () => {
-    expect(isWhiteSpace(' ')).toBe(true);
+    expect(isSpaceOrTab(' ')).toBe(true);
   });
 
   test('true for a tab character', () => {
-    expect(isWhiteSpace('\t')).toBe(true);
+    expect(isSpaceOrTab('\t')).toBe(true);
   });
 
   test('false for a newline character', () => {
-    expect(isWhiteSpace('\n')).toBe(false);
+    expect(isSpaceOrTab('\n')).toBe(false);
   });
 
   test('false for a non-whitespace character', () => {
-    expect(isWhiteSpace('a')).toBe(false);
+    expect(isSpaceOrTab('a')).toBe(false);
   });
 });
 

--- a/tests/utils/is.test.ts
+++ b/tests/utils/is.test.ts
@@ -6,6 +6,7 @@ import {
   isStringArray,
   isStringOrNumber,
   isNestedStringArray,
+  isWhiteSpace,
   isWhitespaceOnly,
   isEmptyString,
   isNoneMode,
@@ -229,6 +230,24 @@ describe('isWhitespaceOnly', () => {
 
   test('false for a string with spaces and characters', () => {
     expect(isWhitespaceOnly('  a  ')).toBe(false);
+  });
+});
+
+describe('isWhiteSpace', () => {
+  test('true for a space character', () => {
+    expect(isWhiteSpace(' ')).toBe(true);
+  });
+
+  test('true for a tab character', () => {
+    expect(isWhiteSpace('\t')).toBe(true);
+  });
+
+  test('false for a newline character', () => {
+    expect(isWhiteSpace('\n')).toBe(false);
+  });
+
+  test('false for a non-whitespace character', () => {
+    expect(isWhiteSpace('a')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Extract quote whitespace predicate into shared utils.

<!-- A brief summary of the changes -->

## Description

Extract the single-character whitespace check used by quote stripping into the shared predicate module and reuse it from strip-outer-quotes. This removes unnecessary internal dependency injection, simplifies helper signatures, and adds focused unit coverage for the new `isWhiteSpace` helper.

<!-- A detailed explanation of the changes, including why they are needed -->
