### PR TITLE
fix: re-export preset option types from package entrypoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,10 @@ export { emailDivider } from '@/presets/email-divider';
 export { pathDivider } from '@/presets/path-divider';
 export { queryDivider } from '@/presets/query-divider';
 export * from './types';
+export type {
+  CsvDividerOptions,
+  EmailDividerOptions,
+  PathDividerOptions,
+  QueryDecodeMode,
+  QueryDividerOptions,
+} from './types/preset';


### PR DESCRIPTION
## Summary

Fix Re-export preset option types from package entrypoint.

<!-- A brief summary of the changes -->

## Description

Re-export preset option types from the package entrypoint.

This makes the following types available directly from the top-level package import:

- `CsvDividerOptions`
- `EmailDividerOptions`
- `PathDividerOptions`
- `QueryDecodeMode`
- `QueryDividerOptions`

<!-- A detailed explanation of the changes, including why they are needed -->
