### PR TITLE
refactor: use while loop for variable-step quote scanning

### DIFF
--- a/src/utils/count-unescaped.ts
+++ b/src/utils/count-unescaped.ts
@@ -21,7 +21,9 @@ const countUnescapedMultiChar = (text: string, quote: string) => {
   const escapedPairLength = escapedPair.length;
   let count = 0;
 
-  for (let index = 0; index < text.length; ) {
+  let index = 0;
+
+  while (index < text.length) {
     if (text.startsWith(escapedPair, index)) {
       index += escapedPairLength;
       continue;


### PR DESCRIPTION
## Summary

Use while loop for variable-step quote scanning.

<!-- A brief summary of the changes -->

## Description

Refactor the multi-character quote scan in `countUnescaped` to use a while loop instead of a for loop with manual index advancement. 
This keeps behavior unchanged while making the variable-step traversal easier to read and reason about.

<!-- A detailed explanation of the changes, including why they are needed -->
