### PR TITLE
fix: pin Deno version for JSR publish

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,10 @@
 [tools]
 node = "22"
 pnpm = "10.33.0"
-deno = "2"
+# WHY: `deno publish` enforces a clean worktree and may rewrite `deno.lock`
+# when lockfile normalization changes across Deno releases. Pin the exact
+# version so local runs and GitHub Actions produce the same lockfile output.
+deno = "2.7.5"
 bun = "latest"
 
 [tasks.lint]


### PR DESCRIPTION
## Summary

Pin Deno version for JSR publish.

<!-- A brief summary of the changes -->

## Description

Pin the `Deno` toolchain in `mise` to 2.7.5 so local runs and GitHub Actions use the same lockfile normalization during JSR publish checks. 

This avoids CI-only `deno.lock` rewrites that cause `deno publish --dry-run` to abort with an uncommitted changes error.

<!-- A detailed explanation of the changes, including why they are needed -->
