### PR TITLE
refactor: split option utilities by responsibility

### DIFF
--- a/src/utils/option-arguments.ts
+++ b/src/utils/option-arguments.ts
@@ -1,0 +1,37 @@
+import type {
+  DividerArgs,
+  DividerSeparator,
+  ExtractedDividerOptions,
+} from '@/types';
+import { isOptions, isStringOrNumber } from '@/utils/is';
+
+/**
+ * Extracts trailing options from a mixed argument list.
+ *
+ * WHY: Centralize the common "last-arg may be options" pattern so callers can
+ * keep their overloads and parsing logic simple and consistent.
+ *
+ * @param args Mixed arguments where the last item may be `DividerOptions`.
+ * @returns Object with `cleanedArgs` (string/number separators only) and
+ * `options` (inferred from `args` or an empty object).
+ */
+export function extractOptions<const TArgs extends DividerArgs>(
+  args: TArgs,
+): {
+  cleanedArgs: DividerSeparator[];
+  options: ExtractedDividerOptions<TArgs>;
+} {
+  const clonedArgs = [...args];
+  const lastArg = clonedArgs.at(-1);
+
+  const options = (
+    isOptions(lastArg) ? (clonedArgs.pop(), lastArg) : {}
+  ) as ExtractedDividerOptions<TArgs>;
+
+  const cleanedArgs = clonedArgs.filter(isStringOrNumber);
+
+  return {
+    cleanedArgs,
+    options,
+  };
+}

--- a/src/utils/option-exclude.ts
+++ b/src/utils/option-exclude.ts
@@ -1,0 +1,21 @@
+import type { DividerInferredOptions } from '@/types';
+import type { SegmentPredicate } from '@/utils/option-types';
+import { excludePredicateMap } from '@/utils/exclude-predicate';
+import { isNoneMode } from '@/utils/is';
+
+/**
+ * Resolves a segment filter for the provided exclude mode.
+ * @param exclude Exclude mode candidate.
+ * @returns Predicate when the mode is supported; otherwise null.
+ */
+export function resolveExcludePredicate(
+  exclude: DividerInferredOptions['exclude'] | unknown,
+): SegmentPredicate | null {
+  if (exclude == null || isNoneMode(exclude) || typeof exclude !== 'string') {
+    return null;
+  }
+
+  return Object.hasOwn(excludePredicateMap, exclude)
+    ? excludePredicateMap[exclude as keyof typeof excludePredicateMap]
+    : null;
+}

--- a/src/utils/option-output.ts
+++ b/src/utils/option-output.ts
@@ -1,0 +1,61 @@
+import type {
+  DividerOutput,
+  SegmentPredicate,
+  SegmentTransformer,
+} from '@/utils/option-types';
+import { isEmptyString, isNestedStringArray } from '@/utils/is';
+
+/**
+ * Maps divider output while preserving its flat or nested shape.
+ * @param output Divider output to transform.
+ * @param transform Transformer applied to each row or flat segment list.
+ * @returns Output with the original shape preserved.
+ */
+export function mapDividerOutput(
+  output: DividerOutput,
+  transform: SegmentTransformer,
+): DividerOutput {
+  return isNestedStringArray(output) ? output.map(transform) : transform(output);
+}
+
+/**
+ * Filters divider output while preserving shape and nested empty-row semantics.
+ * @param output Divider output to filter.
+ * @param shouldKeep Predicate used to retain segments.
+ * @param preserveEmpty When true, retain nested rows that become empty.
+ * @returns Filtered divider output.
+ */
+export function filterDividerOutput(
+  output: DividerOutput,
+  shouldKeep: SegmentPredicate,
+  preserveEmpty: boolean,
+): DividerOutput {
+  if (!isNestedStringArray(output)) {
+    return output.filter(shouldKeep);
+  }
+
+  const filteredRows = output.map((row) => row.filter(shouldKeep));
+  return preserveEmpty
+    ? filteredRows
+    : filteredRows.filter((row) => row.length > 0);
+}
+
+/**
+ * Trims segments while optionally preserving empty outputs.
+ *
+ * WHY: Centralize the flat trimming rule so higher-level option handling stays
+ * focused on orchestration.
+ *
+ * @param segments Segments to trim.
+ * @param preserveEmpty When true, retain empty strings produced by trimming.
+ * @returns Trimmed segments, optionally filtered.
+ */
+export function trimSegments(
+  segments: readonly string[],
+  preserveEmpty: boolean,
+): string[] {
+  const trimmed = segments.map((segment) => segment.trim());
+  return preserveEmpty
+    ? trimmed
+    : trimmed.filter((segment) => !isEmptyString(segment));
+}

--- a/src/utils/option-transformers.ts
+++ b/src/utils/option-transformers.ts
@@ -1,0 +1,58 @@
+import type { DividerInferredOptions } from '@/types';
+import type { DividerOutput } from '@/utils/option-types';
+import { resolveExcludePredicate } from '@/utils/option-exclude';
+import {
+  filterDividerOutput,
+  mapDividerOutput,
+  trimSegments,
+} from '@/utils/option-output';
+import { isNestedStringArray } from '@/utils/is';
+
+/**
+ * Trims segments when the `trim` option is enabled.
+ * @param output Current divider output (flat or nested).
+ * @param options Options to check for `trim`.
+ * @param shouldPreserveEmpty When true, keep empty segments after trimming.
+ * @returns Trimmed output when enabled; otherwise unchanged output.
+ */
+export function applyTrimOption(
+  output: DividerOutput,
+  options: DividerInferredOptions,
+  shouldPreserveEmpty: boolean,
+): DividerOutput {
+  if (!options.trim) return output;
+  return mapDividerOutput(output, (segments) =>
+    trimSegments(segments, shouldPreserveEmpty),
+  );
+}
+
+/**
+ * Flattens nested rows when the `flatten` option is enabled.
+ * @param output Current divider output (flat or nested).
+ * @param options Options to check for `flatten`.
+ * @returns Flattened output when enabled; otherwise unchanged output.
+ */
+export function applyFlattenOption(
+  output: DividerOutput,
+  options: DividerInferredOptions,
+): DividerOutput {
+  return options.flatten && isNestedStringArray(output) ? output.flat() : output;
+}
+
+/**
+ * Applies exclude rules to filter out unwanted segments.
+ * @param output Current divider output (flat or nested).
+ * @param options Options that determine exclusion behavior.
+ * @param shouldPreserveEmpty When true, keep empty rows after filtering.
+ * @returns Filtered output based on exclude mode.
+ */
+export function applyExcludeOption(
+  output: DividerOutput,
+  options: DividerInferredOptions,
+  shouldPreserveEmpty: boolean,
+): DividerOutput {
+  const shouldKeep = resolveExcludePredicate(options.exclude);
+  return shouldKeep == null
+    ? output
+    : filterDividerOutput(output, shouldKeep, shouldPreserveEmpty);
+}

--- a/src/utils/option-types.ts
+++ b/src/utils/option-types.ts
@@ -1,0 +1,16 @@
+import type { DividerArrayResult, DividerStringResult } from '@/types';
+
+/**
+ * Runtime divider output before generic result casting.
+ */
+export type DividerOutput = DividerStringResult | DividerArrayResult;
+
+/**
+ * Transforms a flat row of divider segments.
+ */
+export type SegmentTransformer = (segments: readonly string[]) => string[];
+
+/**
+ * Determines whether a divider segment should be retained.
+ */
+export type SegmentPredicate = (segment: string) => boolean;

--- a/src/utils/option.ts
+++ b/src/utils/option.ts
@@ -3,123 +3,15 @@ import type {
   DividerEmptyOptions,
   DividerInferredOptions,
   DividerResult,
-  DividerStringResult,
-  DividerArrayResult,
-  ExtractedDividerOptions,
-  DividerSeparator,
-  DividerArgs,
 } from '@/types';
 import {
-  isOptions,
-  isNestedStringArray,
-  isNoneMode,
-  isStringOrNumber,
-  isEmptyString,
-} from '@/utils/is';
-import { excludePredicateMap } from '@/utils/exclude-predicate';
+  applyExcludeOption,
+  applyFlattenOption,
+  applyTrimOption,
+} from '@/utils/option-transformers';
+import type { DividerOutput } from '@/utils/option-types';
 
-type DividerOutput = DividerStringResult | DividerArrayResult;
-type SegmentTransformer = (segments: readonly string[]) => string[];
-
-/**
- * Extracts trailing options from a mixed argument list.
- *
- * WHY: Centralize the common "last-arg may be options" pattern so callers can
- * keep their overloads and parsing logic simple and consistent.
- *
- * @param args Mixed arguments where the last item may be `DividerOptions`.
- * @returns Object with `cleanedArgs` (string/number separators only) and
- * `options` (inferred from `args` or an empty object).
- */
-export function extractOptions<const TArgs extends DividerArgs>(
-  args: TArgs,
-): {
-  cleanedArgs: DividerSeparator[];
-  options: ExtractedDividerOptions<TArgs>;
-} {
-  const clonedArgs = [...args];
-  const lastArg = clonedArgs.at(-1);
-
-  const options = (
-    isOptions(lastArg) ? (clonedArgs.pop(), lastArg) : {}
-  ) as ExtractedDividerOptions<TArgs>;
-
-  const cleanedArgs = clonedArgs.filter(isStringOrNumber);
-
-  return {
-    cleanedArgs,
-    options,
-  };
-}
-
-/**
- * Maps divider output while preserving its flat or nested shape.
- * @param output Divider output to transform.
- * @param transform Transformer applied to each row or flat segment list.
- * @returns Output with the original shape preserved.
- */
-function mapDividerOutput(
-  output: DividerOutput,
-  transform: SegmentTransformer,
-): DividerOutput {
-  return isNestedStringArray(output) ? output.map(transform) : transform(output);
-}
-
-/**
- * Filters divider output while preserving shape and nested empty-row semantics.
- * @param output Divider output to filter.
- * @param shouldKeep Predicate used to retain segments.
- * @param preserveEmpty When true, retain nested rows that become empty.
- * @returns Filtered divider output.
- */
-function filterDividerOutput(
-  output: DividerOutput,
-  shouldKeep: (segment: string) => boolean,
-  preserveEmpty: boolean,
-): DividerOutput {
-  if (!isNestedStringArray(output)) {
-    return output.filter(shouldKeep);
-  }
-
-  const filteredRows = output.map((row) => row.filter(shouldKeep));
-  return preserveEmpty
-    ? filteredRows
-    : filteredRows.filter((row) => row.length > 0);
-}
-
-/**
- * Resolves a segment filter for the provided exclude mode.
- * @param exclude Exclude mode candidate.
- * @returns Predicate when the mode is supported; otherwise null.
- */
-function resolveExcludePredicate(
-  exclude: DividerInferredOptions['exclude'] | unknown,
-): ((segment: string) => boolean) | null {
-  if (exclude == null || isNoneMode(exclude) || typeof exclude !== 'string') {
-    return null;
-  }
-
-  return Object.hasOwn(excludePredicateMap, exclude)
-    ? excludePredicateMap[exclude as keyof typeof excludePredicateMap]
-    : null;
-}
-
-/**
- * Trims segments while optionally preserving empty outputs.
- * WHY: centralize the flat trimming logic so higher-level option handling stays simple.
- * @param segments Segments to trim.
- * @param preserveEmpty When true, retain empty strings produced by trimming.
- * @returns Trimmed segments, optionally filtered.
- */
-function trimSegments(
-  segments: readonly string[],
-  preserveEmpty: boolean,
-): string[] {
-  const trimmed = segments.map((segment) => segment.trim());
-  return preserveEmpty
-    ? trimmed
-    : trimmed.filter((segment) => !isEmptyString(segment));
-}
+export { extractOptions } from '@/utils/option-arguments';
 
 /**
  * Applies `DividerOptions` to a divided result.
@@ -149,50 +41,3 @@ export function applyDividerOptions<
 
   return output as DividerResult<T, O>;
 }
-
-/**
- * Trims segments when the `trim` option is enabled.
- * @param output Current divider output (flat or nested).
- * @param options Options to check for `trim`.
- * @param shouldPreserveEmpty When true, keep empty segments after trimming.
- * @returns Trimmed output when enabled; otherwise unchanged output.
- */
-const applyTrimOption = (
-  output: DividerOutput,
-  options: DividerInferredOptions,
-  shouldPreserveEmpty: boolean,
-) => {
-  if (!options.trim) return output;
-  return mapDividerOutput(output, (segments) =>
-    trimSegments(segments, shouldPreserveEmpty),
-  );
-};
-
-/**
- * Flattens nested rows when the `flatten` option is enabled.
- * @param output Current divider output (flat or nested).
- * @param options Options to check for `flatten`.
- * @returns Flattened output when enabled; otherwise unchanged output.
- */
-const applyFlattenOption = (
-  output: DividerOutput,
-  options: DividerInferredOptions,
-) => (options.flatten && isNestedStringArray(output) ? output.flat() : output);
-
-/**
- * Applies exclude rules to filter out unwanted segments.
- * @param output Current divider output (flat or nested).
- * @param options Options that determine exclusion behavior.
- * @param shouldPreserveEmpty When true, keep empty rows after filtering.
- * @returns Filtered output based on exclude mode.
- */
-const applyExcludeOption = (
-  output: DividerOutput,
-  options: DividerInferredOptions,
-  shouldPreserveEmpty: boolean,
-) => {
-  const shouldKeep = resolveExcludePredicate(options.exclude);
-  return shouldKeep == null
-    ? output
-    : filterDividerOutput(output, shouldKeep, shouldPreserveEmpty);
-};


### PR DESCRIPTION
## Summary

Split option utilities by responsibility.

<!-- A brief summary of the changes -->

## Description

- Split option argument parsing, output helpers, exclude resolution, transformers, and shared option types out of `src/utils/option.ts`
- Keep `applyDividerOptions` as the orchestration entry point in `option.ts`
- Re-export `extractOptions` from `option.ts` to preserve the existing import surface


<!-- A detailed explanation of the changes, including why they are needed -->
