### PR TITLE
refactor: decouple dividePreserve from divider

### DIFF
--- a/src/utils/divide-preserve.ts
+++ b/src/utils/divide-preserve.ts
@@ -1,12 +1,12 @@
-import { divider } from '@/core/divider';
 import { isEmptyString } from '@/utils/is';
+import { getRegex } from '@/utils/regex';
 
 /**
  * Divide a string by a single separator while preserving empty fields.
  *
- * WHY: This reuses the core divider behavior so delimiter handling stays
- * consistent with the rest of the library while keeping consecutive and
- * trailing empty segments intact.
+ * WHY: Presets and quoted parsing need preserving split behavior without
+ * depending on the public `divider` API. Reusing the regex builder keeps
+ * delimiter escaping and normalization consistent with core division.
  *
  * @param input Source string to divide. Empty string yields a single empty field.
  * @param separator Separator used to divide the string.
@@ -14,5 +14,7 @@ import { isEmptyString } from '@/utils/is';
  */
 export function dividePreserve(input: string, separator: string): string[] {
   if (isEmptyString(input)) return [''];
-  return divider(input, separator, { preserveEmpty: true });
+
+  const regex = getRegex([separator]);
+  return regex == null ? [input] : input.split(regex);
 }

--- a/tests/utils/quoted.test.ts
+++ b/tests/utils/quoted.test.ts
@@ -23,6 +23,14 @@ describe('dividePreserve', () => {
   it('returns single empty field for empty input', () => {
     expect(dividePreserve('', ',')).toEqual(['']);
   });
+
+  it('treats regex metacharacters as literal separators', () => {
+    expect(dividePreserve('a.b.', '.')).toEqual(['a', 'b', '']);
+  });
+
+  it('returns original input when separator is empty', () => {
+    expect(dividePreserve('abc', '')).toEqual(['abc']);
+  });
 });
 
 describe('countUnescaped', () => {


### PR DESCRIPTION
## Summary

Decouple dividePreserve from divider.

<!-- A brief summary of the changes -->

## Description

- Refactored `dividePreserve` to use the lower-level regex splitter instead of calling the public `divider` API
- Preserved existing empty-field behavior for consecutive, leading, and trailing separators
- Added regression coverage for regex metacharacter separators and empty separators

<!-- A detailed explanation of the changes, including why they are needed -->
