### PR TITLE
refactor: extract divider argument plan

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Lint, test, and build
-        run: pnpm lint && pnpm test && pnpm build
+      - name: Lint, test, type-test, and build
+        run: pnpm lint && pnpm test && pnpm run test:types && pnpm build
 
       - name: Publish Package
         run: pnpm publish --access public --no-git-checks --ignore-scripts

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,3 +20,6 @@ jobs:
 
       - name: Run tests
         run: mise run test
+
+      - name: Run type tests
+        run: mise run test_types

--- a/mise.toml
+++ b/mise.toml
@@ -19,6 +19,9 @@ run = "pnpm build"
 [tasks.test]
 run = "pnpm test"
 
+[tasks.test_types]
+run = "pnpm run test:types"
+
 [tasks.test_unit]
 run = "pnpm run test:unit"
 
@@ -26,7 +29,7 @@ run = "pnpm run test:unit"
 run = "pnpm run test:performance"
 
 [tasks.qa]
-run = ["pnpm lint", "pnpm test", "pnpm build"]
+run = ["pnpm lint", "pnpm test", "pnpm run test:types", "pnpm build"]
 
 [tasks.typedoc_build]
 run = "pnpm typedoc --out docs-temp"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "test": "jest",
+    "test:types": "tsc -p tests/tsconfig.json",
     "test:performance": "jest --config jest.performance.config.cjs",
     "test:unit": "jest --testPathIgnorePatterns=performance",
     "lint": "eslint .",

--- a/src/core/divider-plan.ts
+++ b/src/core/divider-plan.ts
@@ -1,0 +1,39 @@
+import type { DividerArgs, ExtractedDividerOptions } from '@/types';
+import { extractOptions } from '@/utils/option';
+import { classifySeparators } from '@/utils/separator';
+
+/**
+ * Parsed execution plan for a `divider` call.
+ */
+export type DividerPlan<TArgs extends DividerArgs> = {
+  /** Numeric separators used as slice indexes */
+  readonly numSeparators: readonly number[];
+  /** String separators used as literal delimiters */
+  readonly strSeparators: readonly string[];
+  /** Trailing options extracted from the original arguments */
+  readonly options: ExtractedDividerOptions<TArgs>;
+};
+
+/**
+ * Converts variadic divider arguments into the normalized plan used at runtime.
+ *
+ * WHY: `divider` accepts a compact public argument shape, but execution needs
+ * typed groups for numeric separators, string separators, and trailing options.
+ * Keeping that translation in one place protects the public overload from
+ * accumulating parsing details as additional separator behavior is added.
+ *
+ * @param args Variadic divider arguments.
+ * @returns Normalized separator groups and extracted options.
+ */
+export function createDividerPlan<const TArgs extends DividerArgs>(
+  args: TArgs,
+): DividerPlan<TArgs> {
+  const { cleanedArgs, options } = extractOptions(args);
+  const { numSeparators, strSeparators } = classifySeparators(cleanedArgs);
+
+  return {
+    numSeparators,
+    strSeparators,
+    options,
+  };
+}

--- a/src/core/divider.ts
+++ b/src/core/divider.ts
@@ -2,9 +2,8 @@ import type { DividerInput, DividerArgs, DividerReturn } from '@/types';
 import { divideString } from '@/utils/parser';
 import { isEmptyArray, isValidInput } from '@/utils/is';
 import { ensureStringArray } from '@/utils/array';
-import { extractOptions } from '@/utils/option';
-import { classifySeparators } from '@/utils/separator';
 import { transformDividerInput } from '@/utils/transform-divider-input';
+import { createDividerPlan } from '@/core/divider-plan';
 
 /**
  * Main divider function that splits input based on numeric positions or string delimiters.
@@ -36,9 +35,7 @@ export function divider(input: DividerInput, ...args: DividerArgs) {
     return ensureStringArray(input);
   }
 
-  // Extract options and clean arguments
-  const { cleanedArgs, options } = extractOptions(args);
-  const { numSeparators, strSeparators } = classifySeparators(cleanedArgs);
+  const { numSeparators, strSeparators, options } = createDividerPlan(args);
 
   const applyDivision = (str: string) =>
     divideString(str, numSeparators, strSeparators, {

--- a/tests/core/divider-plan.test.ts
+++ b/tests/core/divider-plan.test.ts
@@ -1,0 +1,40 @@
+import { createDividerPlan } from '../../src/core/divider-plan';
+import type { DividerArgs } from '../../src/types';
+
+describe('createDividerPlan', () => {
+  it('groups numeric and string separators while extracting trailing options', () => {
+    const args = [
+      2,
+      ',',
+      5,
+      '-',
+      { trim: true, preserveEmpty: true },
+    ] as const satisfies DividerArgs;
+
+    expect(createDividerPlan(args)).toEqual({
+      numSeparators: [2, 5],
+      strSeparators: [',', '-'],
+      options: { trim: true, preserveEmpty: true },
+    });
+  });
+
+  it('uses empty options when no trailing options object is provided', () => {
+    const args = [1, '/', '\\'] as const satisfies DividerArgs;
+
+    expect(createDividerPlan(args)).toEqual({
+      numSeparators: [1],
+      strSeparators: ['/', '\\'],
+      options: {},
+    });
+  });
+
+  it('handles an empty argument list', () => {
+    const args = [] as const satisfies DividerArgs;
+
+    expect(createDividerPlan(args)).toEqual({
+      numSeparators: [],
+      strSeparators: [],
+      options: {},
+    });
+  });
+});

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -3,6 +3,10 @@
   "compilerOptions": {
     "noEmit": true,
     "rootDir": "..",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@nyaomaru/divider": ["./src/index.ts"]
+    },
     "types": ["jest", "node"]
   },
   "include": ["./**/*.ts", "../src/**/*.ts"],

--- a/tests/types/divider-contract.test.ts
+++ b/tests/types/divider-contract.test.ts
@@ -1,0 +1,27 @@
+import { divider } from '../../src';
+
+const expectType = <TExpected>(value: TExpected): void => {
+  void value;
+};
+
+describe('divider type contract', () => {
+  it('keeps compile-time result inference stable', () => {
+    expectType<string[]>(divider('a,b', ','));
+    expectType<string[][]>(divider(['a,b', 'c,d'], ','));
+    expectType<string[]>(
+      divider(['a,b', 'c,d'], ',', {
+        flatten: true,
+      }),
+    );
+    expectType<readonly ['a', 'b']>(divider(['a', 'b'] as const));
+
+    const dynamicFlatten = true as boolean;
+    expectType<string[][]>(
+      divider(['a,b'], ',', {
+        flatten: dynamicFlatten,
+      }),
+    );
+
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Extract divider argument plan.

<!-- A brief summary of the changes -->

## Description

- Extract divider argument normalization into `createDividerPlan`
- Keep `divider` focused on validation, splitting, and option application
- Add runtime tests for divider plan creation


<!-- A detailed explanation of the changes, including why they are needed -->
