### PR TITLE
refactor: extract query parsing utilities

### DIFF
--- a/src/presets/query-divider.ts
+++ b/src/presets/query-divider.ts
@@ -1,120 +1,6 @@
 import type { DividerArrayResult } from '@/types';
-import type { QueryDividerOptions, QueryDecodeMode } from '@/types/preset';
-import { QUERY_DECODE_MODES, QUERY_SEPARATORS } from '@/constants';
-import { dividePreserve } from '@/utils/divide-preserve';
-
-// WHY: Preserve consecutive and trailing empty segments to reflect query strings precisely
-// (e.g., 'a=&b&=c&' keeps empties). Split helpers isolate concerns for readability and testability.
-
-/**
- * Extract the query component from a full URL when possible.
- * Returns the URL's search part without the leading '?' when input is a URL; otherwise returns the original input.
- * @param input String potentially containing a full URL.
- * @returns Query string without leading '?' or the original input.
- */
-function tryExtractQuery(input: string): string {
-  try {
-    const url = new URL(input);
-    return url.search.startsWith(QUERY_SEPARATORS.QUESTION_MARK)
-      ? url.search.slice(1)
-      : url.search;
-  } catch {
-    return extractQueryFromQuestionMark(input);
-  }
-}
-
-/**
- * Extract query substring from a non-absolute URL-like input.
- * WHY: Relative URLs (e.g. "/path?a=1&b=2#frag") cannot be passed to `new URL`
- * without a base, so this fallback keeps query parsing behavior consistent.
- * @param input Raw input string that may contain path/query/fragment.
- * @returns Query portion when `?` exists before `#`; otherwise the original input without fragment.
- */
-function extractQueryFromQuestionMark(input: string): string {
-  const fragmentIndex = input.indexOf('#');
-  const withoutFragment =
-    fragmentIndex >= 0 ? input.slice(0, fragmentIndex) : input;
-
-  const questionMarkIndex = withoutFragment.indexOf(
-    QUERY_SEPARATORS.QUESTION_MARK,
-  );
-
-  // Only treat '?' as starting the query when:
-  // - it is the very first character (e.g. '?a=1'), or
-  // - there is no '=' or '&' before it (looks like '/path?query').
-  // Otherwise, assume it's part of a raw query value/key and keep the string intact.
-  if (questionMarkIndex < 0) {
-    return withoutFragment;
-  }
-
-  // Leading '?' – behave like URL.search and strip it.
-  if (questionMarkIndex === 0) {
-    return withoutFragment.slice(1);
-  }
-
-  const prefix = withoutFragment.slice(0, questionMarkIndex);
-  const hasQuerySeparatorBefore =
-    prefix.includes(QUERY_SEPARATORS.AMPERSAND) ||
-    prefix.includes(QUERY_SEPARATORS.EQUALS);
-
-  if (hasQuerySeparatorBefore) {
-    // Looks like a raw query string (e.g. 'a=b?c=d'); do not split on '?'.
-    return withoutFragment;
-  }
-
-  // Treat as path?query and return the part after '?'.
-  return withoutFragment.slice(questionMarkIndex + 1);
-}
-
-/**
- * Remove a single leading '?' from a query string if present.
- * @param query Query string that may start with '?'.
- * @returns Query string without the leading '?'.
- */
-function stripLeadingQuestionMark(query: string): string {
-  return query.startsWith(QUERY_SEPARATORS.QUESTION_MARK)
-    ? query.slice(1)
-    : query;
-}
-
-/**
- * Split a key-value part on the first '=' only, preserving additional '=' in the value.
- * Empty keys/values are preserved to reflect the exact input.
- * @param part A single 'key=value' segment (may be empty or without '=').
- * @returns Tuple [key, value] with empty strings where appropriate.
- */
-function splitOnFirstEquals(part: string): [string, string] {
-  const kv = dividePreserve(part, QUERY_SEPARATORS.EQUALS);
-  if (kv.length === 1) return [kv[0] ?? '', ''];
-  return [kv[0] ?? '', kv.slice(1).join(QUERY_SEPARATORS.EQUALS)];
-}
-
-/**
- * Decode a query field according to the selected mode, then optionally trim.
- * - 'auto': replace '+' with space and apply decodeURIComponent (ignore malformed escapes)
- * - 'raw': leave text untouched
- * @param text Field text to decode.
- * @param mode Decoding mode: 'auto' or 'raw'.
- * @param trim Whether to trim the resulting text.
- * @returns Decoded (and optionally trimmed) field value.
- */
-function decodeField(
-  text: string,
-  mode: QueryDecodeMode,
-  trim: boolean,
-): string {
-  let t = text;
-  if (mode === QUERY_DECODE_MODES.AUTO) {
-    t = t.replace(/\+/g, ' ');
-    try {
-      t = decodeURIComponent(t);
-    } catch {
-      // leave undecoded on malformed escape sequences
-    }
-  }
-  if (trim) t = t.trim();
-  return t;
-}
+import type { QueryDividerOptions } from '@/types/preset';
+import { parseQueryPairs } from '@/utils/query';
 
 /**
  * Divide a query string into key/value pairs.
@@ -127,15 +13,7 @@ function decodeField(
  */
 export function queryDivider(
   input: string,
-  { mode = QUERY_DECODE_MODES.AUTO, trim = false }: QueryDividerOptions = {},
+  options: QueryDividerOptions = {},
 ): DividerArrayResult {
-  if (input.length === 0) return [];
-
-  const query = stripLeadingQuestionMark(tryExtractQuery(input));
-  if (query.length === 0) return [];
-
-  return dividePreserve(query, QUERY_SEPARATORS.AMPERSAND).map((part) => {
-    const [key, value] = splitOnFirstEquals(part);
-    return [decodeField(key, mode, trim), decodeField(value, mode, trim)];
-  });
+  return parseQueryPairs(input, options);
 }

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -1,0 +1,130 @@
+import { QUERY_DECODE_MODES, QUERY_SEPARATORS } from '@/constants';
+import type { DividerArrayResult } from '@/types';
+import type { QueryDecodeMode, QueryDividerOptions } from '@/types/preset';
+import { dividePreserve } from '@/utils/divide-preserve';
+
+/**
+ * Extracts query text from an absolute URL, relative URL, or raw query string.
+ * @param input String that may be a URL, URL-like path, or raw query.
+ * @returns Query string without a leading question mark when one is detected.
+ */
+export function extractQuery(input: string): string {
+  try {
+    const url = new URL(input);
+    return stripLeadingQuestionMark(url.search);
+  } catch {
+    return extractQueryFromQuestionMark(input);
+  }
+}
+
+/**
+ * Extracts query text from non-absolute URL-like input.
+ *
+ * WHY: Relative URLs cannot be passed to `new URL` without a base, while raw
+ * query values can legitimately contain `?`. The prefix check keeps both cases
+ * distinguishable without requiring callers to classify the input first.
+ *
+ * @param input Raw input string that may contain path, query, or fragment text.
+ * @returns Query portion when `?` is a URL boundary; otherwise the input without fragment.
+ */
+export function extractQueryFromQuestionMark(input: string): string {
+  const fragmentIndex = input.indexOf('#');
+  const withoutFragment =
+    fragmentIndex >= 0 ? input.slice(0, fragmentIndex) : input;
+
+  const questionMarkIndex = withoutFragment.indexOf(
+    QUERY_SEPARATORS.QUESTION_MARK,
+  );
+
+  if (questionMarkIndex < 0) {
+    return withoutFragment;
+  }
+
+  if (questionMarkIndex === 0) {
+    return withoutFragment.slice(1);
+  }
+
+  const prefix = withoutFragment.slice(0, questionMarkIndex);
+  const hasQuerySeparatorBefore =
+    prefix.includes(QUERY_SEPARATORS.AMPERSAND) ||
+    prefix.includes(QUERY_SEPARATORS.EQUALS);
+
+  return hasQuerySeparatorBefore
+    ? withoutFragment
+    : withoutFragment.slice(questionMarkIndex + 1);
+}
+
+/**
+ * Removes one leading question mark from query text.
+ * @param query Query string that may start with `?`.
+ * @returns Query string without one leading question mark.
+ */
+export function stripLeadingQuestionMark(query: string): string {
+  return query.startsWith(QUERY_SEPARATORS.QUESTION_MARK)
+    ? query.slice(1)
+    : query;
+}
+
+/**
+ * Splits a query part into a key/value tuple on the first equals sign.
+ * @param part Query part such as `key=value`.
+ * @returns Tuple with empty strings for missing key or value positions.
+ */
+export function splitQueryPair(part: string): [string, string] {
+  const keyValue = dividePreserve(part, QUERY_SEPARATORS.EQUALS);
+  if (keyValue.length === 1) return [keyValue[0] ?? '', ''];
+  return [
+    keyValue[0] ?? '',
+    keyValue.slice(1).join(QUERY_SEPARATORS.EQUALS),
+  ];
+}
+
+/**
+ * Decodes a query key or value according to the selected mode.
+ * @param text Query field text to decode.
+ * @param mode Decoding mode.
+ * @param trim Whether to trim after decoding.
+ * @returns Decoded query field text.
+ */
+export function decodeQueryField(
+  text: string,
+  mode: QueryDecodeMode,
+  trim: boolean,
+): string {
+  let decoded = text;
+
+  if (mode === QUERY_DECODE_MODES.AUTO) {
+    decoded = decoded.replace(/\+/g, ' ');
+    try {
+      decoded = decodeURIComponent(decoded);
+    } catch {
+      // Malformed escape sequences should not make query parsing fail.
+    }
+  }
+
+  return trim ? decoded.trim() : decoded;
+}
+
+/**
+ * Parses query input into key/value pairs.
+ * @param input Query string or URL containing a query string.
+ * @param options Query parsing options.
+ * @returns Parsed key/value pairs in input order.
+ */
+export function parseQueryPairs(
+  input: string,
+  { mode = QUERY_DECODE_MODES.AUTO, trim = false }: QueryDividerOptions = {},
+): DividerArrayResult {
+  if (input.length === 0) return [];
+
+  const query = stripLeadingQuestionMark(extractQuery(input));
+  if (query.length === 0) return [];
+
+  return dividePreserve(query, QUERY_SEPARATORS.AMPERSAND).map((part) => {
+    const [key, value] = splitQueryPair(part);
+    return [
+      decodeQueryField(key, mode, trim),
+      decodeQueryField(value, mode, trim),
+    ];
+  });
+}

--- a/tests/utils/query.test.ts
+++ b/tests/utils/query.test.ts
@@ -1,0 +1,72 @@
+import {
+  decodeQueryField,
+  extractQuery,
+  parseQueryPairs,
+  splitQueryPair,
+  stripLeadingQuestionMark,
+} from '../../src/utils/query';
+
+describe('query utilities', () => {
+  describe('extractQuery', () => {
+    it('extracts query text from absolute and relative URLs', () => {
+      expect(extractQuery('https://example.com/path?a=1&b=2#hash')).toBe(
+        'a=1&b=2',
+      );
+      expect(extractQuery('/path/to/resource?a=1&b=2#hash')).toBe('a=1&b=2');
+    });
+
+    it('keeps a question mark inside raw query text', () => {
+      expect(extractQuery('a=b?c=d')).toBe('a=b?c=d');
+    });
+
+    it('removes fragments from query-like input', () => {
+      expect(extractQuery('?q=hello#hash')).toBe('q=hello');
+    });
+  });
+
+  describe('stripLeadingQuestionMark', () => {
+    it('removes only one leading question mark', () => {
+      expect(stripLeadingQuestionMark('?a=1')).toBe('a=1');
+      expect(stripLeadingQuestionMark('??a=1')).toBe('?a=1');
+    });
+  });
+
+  describe('splitQueryPair', () => {
+    it('splits on the first equals sign only', () => {
+      expect(splitQueryPair('a=1=2')).toEqual(['a', '1=2']);
+    });
+
+    it('preserves missing keys and values', () => {
+      expect(splitQueryPair('b')).toEqual(['b', '']);
+      expect(splitQueryPair('=c')).toEqual(['', 'c']);
+    });
+  });
+
+  describe('decodeQueryField', () => {
+    it('decodes plus signs and percent escapes in auto mode', () => {
+      expect(decodeQueryField('hello+%E3%81%82', 'auto', false)).toBe(
+        'hello あ',
+      );
+    });
+
+    it('keeps malformed percent escapes unchanged', () => {
+      expect(decodeQueryField('%E0%A4%A', 'auto', false)).toBe('%E0%A4%A');
+    });
+
+    it('supports raw and trim modes', () => {
+      expect(decodeQueryField('+a+', 'raw', false)).toBe('+a+');
+      expect(decodeQueryField('+a+', 'auto', true)).toBe('a');
+    });
+  });
+
+  describe('parseQueryPairs', () => {
+    it('preserves empty keys, values, and trailing separators', () => {
+      expect(parseQueryPairs('a=&b&=c&')).toEqual([
+        ['a', ''],
+        ['b', ''],
+        ['', 'c'],
+        ['', ''],
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Extract query parsing utilities.

<!-- A brief summary of the changes -->

## Description

- Extract query parsing helpers from `queryDivider` into `src/utils/query.ts`
- Keep `queryDivider` as a thin preset wrapper around `parseQueryPairs`
- Add focused unit tests for query extraction, pair splitting, decoding, and empty segment preservation

<!-- A detailed explanation of the changes, including why they are needed -->
