### PR TITLE
fix: read bumped version from package metadata

### DIFF
--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -8,9 +8,9 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: 'Select version bump type'
+        description: "Select version bump type"
         required: true
-        default: 'patch'
+        default: "patch"
         type: choice
         options:
           - patch
@@ -54,9 +54,9 @@ jobs:
         id: version
         run: |
           set -euo pipefail
-          NEW_VERSION=$(pnpm version ${{ inputs.release_type }} --no-git-tag-version | awk '{print $NF}')
-          version_no_v=${NEW_VERSION#v}
-          echo "new_version=$version_no_v" >> $GITHUB_ENV
+          pnpm version ${{ inputs.release_type }} --no-git-tag-version
+          version_no_v=$(node -p "require('./package.json').version")
+          printf 'new_version=%s\n' "$version_no_v" >> "$GITHUB_ENV"
           tmp_jsr=$(mktemp)
           jq --arg version "$version_no_v" '.version = $version' jsr.json > "$tmp_jsr"
           mv "$tmp_jsr" jsr.json


### PR DESCRIPTION
## Summary

Fix to read bumped version from package metadata.

<!-- A brief summary of the changes -->

## Description

- Fix version bump workflow failure when writing `new_version` to `$GITHUB_ENV`
- Stop parsing `pnpm version` stdout and read the updated version from `package.json`
- Format the workflow with Prettier

<!-- A detailed explanation of the changes, including why they are needed -->
