### PR TITLE
refactor: split guard utilities by concern

### DIFF
--- a/src/core/divider-loop.ts
+++ b/src/core/divider-loop.ts
@@ -1,4 +1,4 @@
-import { isPositiveInteger } from '@/utils/is';
+import { isPositiveInteger } from '@/utils/guards/primitives';
 import { generateIndexes } from '@/utils/generate-indexes';
 import { shouldTruncateChunks, truncateChunksToMax } from '@/utils/chunk';
 import type {

--- a/src/core/divider.ts
+++ b/src/core/divider.ts
@@ -1,6 +1,7 @@
 import type { DividerInput, DividerArgs, DividerReturn } from '@/types';
 import { divideString } from '@/utils/parser';
-import { isEmptyArray, isValidInput } from '@/utils/is';
+import { isEmptyArray } from '@/utils/guards/array';
+import { isValidInput } from '@/utils/guards/divider-input';
 import { ensureStringArray } from '@/utils/array';
 import { transformDividerInput } from '@/utils/transform-divider-input';
 import { createDividerPlan } from '@/core/divider-plan';

--- a/src/presets/path-divider.ts
+++ b/src/presets/path-divider.ts
@@ -2,7 +2,7 @@ import { divider } from '@/core/divider';
 import type { DividerStringResult } from '@/types';
 import type { PathDividerOptions } from '@/types/preset';
 import { dividePreserve } from '@/utils/divide-preserve';
-import { isEmptyString } from '@/utils/is';
+import { isEmptyString } from '@/utils/guards/whitespace';
 import { PATH_SEPARATORS } from '@/constants';
 
 /**

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,5 +1,5 @@
 import type { DividerInput } from '@/types';
-import { isString } from '@/utils/is';
+import { isString } from '@/utils/guards/primitives';
 
 /**
  * Ensures that the input is returned as a string array.

--- a/src/utils/chunk.ts
+++ b/src/utils/chunk.ts
@@ -1,4 +1,4 @@
-import { isNumber } from '@/utils/is';
+import { isNumber } from '@/utils/guards/primitives';
 
 // Constants for better maintainability
 const MIN_ALLOWED_CHUNKS = 0;

--- a/src/utils/count-unescaped.ts
+++ b/src/utils/count-unescaped.ts
@@ -1,4 +1,4 @@
-import { isEmptyString } from '@/utils/is';
+import { isEmptyString } from '@/utils/guards/whitespace';
 
 const countUnescapedSingleChar = (text: string, quote: string) => {
   let count = 0;

--- a/src/utils/divide-preserve.ts
+++ b/src/utils/divide-preserve.ts
@@ -1,4 +1,4 @@
-import { isEmptyString } from '@/utils/is';
+import { isEmptyString } from '@/utils/guards/whitespace';
 import { getRegex } from '@/utils/regex';
 
 /**

--- a/src/utils/exclude-predicate.ts
+++ b/src/utils/exclude-predicate.ts
@@ -1,5 +1,8 @@
 import type { DividerExcludeMode } from '@/types';
-import { isEmptyString, isWhitespaceOnly } from '@/utils/is';
+import {
+  isEmptyString,
+  isWhitespaceOnly,
+} from '@/utils/guards/whitespace';
 
 /**
  * A mapping of `exclude` modes to their corresponding filter predicates.

--- a/src/utils/generate-indexes.ts
+++ b/src/utils/generate-indexes.ts
@@ -1,4 +1,4 @@
-import { isPositiveInteger } from '@/utils/is';
+import { isPositiveInteger } from '@/utils/guards/primitives';
 
 /**
  * Generates an array of index positions to divide a string into chunks.

--- a/src/utils/guards/array.ts
+++ b/src/utils/guards/array.ts
@@ -1,0 +1,32 @@
+import { isString } from '@/utils/guards/primitives';
+
+/**
+ * Determines whether the provided array is empty.
+ * @param value Array to inspect.
+ * @returns True when the array contains no elements.
+ */
+export function isEmptyArray<T>(value: readonly T[]): boolean {
+  return Array.isArray(value) && value.length === 0;
+}
+
+/**
+ * Determines whether the value is an array populated solely by strings.
+ * @param value Value to inspect.
+ * @returns True when the value is a string array.
+ */
+export function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every(isString);
+}
+
+/**
+ * Determines whether the value is a non-empty nested array of strings.
+ * @param value Value to inspect.
+ * @returns True when the value is a nested string array.
+ */
+export function isNestedStringArray(value: unknown): value is string[][] {
+  if (!Array.isArray(value) || value.length === 0) return false;
+  const firstRow = value[0];
+  // WHY: Divider outputs are trusted; checking only the first row avoids
+  // a full scan while still distinguishing nested vs flat arrays.
+  return Array.isArray(firstRow) && firstRow.every((item) => isString(item));
+}

--- a/src/utils/guards/divider-input.ts
+++ b/src/utils/guards/divider-input.ts
@@ -1,0 +1,11 @@
+import type { DividerInput } from '@/types';
+import { isString } from '@/utils/guards/primitives';
+
+/**
+ * Determines whether the value is a string or readonly array of strings.
+ * @param value Value to inspect.
+ * @returns True when the value is a string or an array of strings.
+ */
+export function isValidInput(value: unknown): value is DividerInput {
+  return isString(value) || (Array.isArray(value) && value.every(isString));
+}

--- a/src/utils/guards/options.ts
+++ b/src/utils/guards/options.ts
@@ -1,0 +1,26 @@
+import type { DividerOptions } from '@/types';
+import { DIVIDER_EXCLUDE_MODES, DIVIDER_OPTION_KEYS } from '@/constants';
+import { isPlainObject } from '@/utils/guards/primitives';
+
+/**
+ * Validates that the value matches the DividerOptions contract.
+ * @param value Value to inspect.
+ * @returns True when the value owns at least one known option key.
+ */
+export function isOptions(value: unknown): value is DividerOptions {
+  if (!isPlainObject(value)) return false;
+  const options = value;
+
+  return DIVIDER_OPTION_KEYS.some((key) => Object.hasOwn(options, key));
+}
+
+/**
+ * Determines whether the provided value matches the exclude mode `none`.
+ * @param value Value to inspect.
+ * @returns True when the value equals `none`.
+ */
+export function isNoneMode(
+  value: unknown
+): value is typeof DIVIDER_EXCLUDE_MODES.NONE {
+  return value === DIVIDER_EXCLUDE_MODES.NONE;
+}

--- a/src/utils/guards/primitives.ts
+++ b/src/utils/guards/primitives.ts
@@ -1,0 +1,57 @@
+/**
+ * Determines whether the provided value is a string.
+ * @param value Value to inspect.
+ * @returns True when the value is a string.
+ */
+export function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+/**
+ * Determines whether the provided value is a number.
+ * @param value Value to inspect.
+ * @returns True when the value is a number.
+ */
+export function isNumber(value: unknown): value is number {
+  return typeof value === 'number';
+}
+
+/**
+ * Determines whether the provided value is an object excluding null.
+ * @param value Value to inspect.
+ * @returns True when the value is an object.
+ */
+function isObject(value: unknown): value is object {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Determines whether the value is a plain object with a simple prototype chain.
+ * @param value Value to inspect.
+ * @returns True when the value behaves like a plain object.
+ */
+export function isPlainObject(
+  value: unknown
+): value is Record<string, unknown> {
+  if (!isObject(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === null || Object.getPrototypeOf(proto) === null;
+}
+
+/**
+ * Determines whether the provided value is a positive integer.
+ * @param value Value to inspect.
+ * @returns True when the value is an integer greater than zero.
+ */
+export function isPositiveInteger(value: unknown): boolean {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0;
+}
+
+/**
+ * Determines whether the value is a string or a number.
+ * @param value Value to inspect.
+ * @returns True when the value is a primitive string or number.
+ */
+export function isStringOrNumber(value: unknown): value is string | number {
+  return isString(value) || isNumber(value);
+}

--- a/src/utils/guards/whitespace.ts
+++ b/src/utils/guards/whitespace.ts
@@ -1,0 +1,28 @@
+import { TAB, WHITE_SPACE } from '@/constants';
+
+/**
+ * Determines whether the provided character is a space or tab.
+ * @param value Character to inspect.
+ * @returns True when the character is a space or tab.
+ */
+export function isSpaceOrTab(value: string): boolean {
+  return value === WHITE_SPACE || value === TAB;
+}
+
+/**
+ * Determines whether the provided string contains only whitespace characters.
+ * @param value String to inspect.
+ * @returns True when the string trims to an empty value.
+ */
+export function isWhitespaceOnly(value: string): boolean {
+  return value.trim() === '';
+}
+
+/**
+ * Determines whether the provided string is empty.
+ * @param value String to inspect.
+ * @returns True when the string length is zero.
+ */
+export function isEmptyString(value: string): boolean {
+  return value === '';
+}

--- a/src/utils/is.ts
+++ b/src/utils/is.ts
@@ -1,155 +1,19 @@
-import type { DividerOptions, DividerInput } from '@/types';
-import {
-  DIVIDER_EXCLUDE_MODES,
-  DIVIDER_OPTION_KEYS,
-  TAB,
-  WHITE_SPACE,
-} from '@/constants';
-
-/**
- * Determines whether the provided value is a string.
- * @param value Value to inspect.
- * @returns True when the value is a string.
- */
-export function isString(value: unknown): value is string {
-  return typeof value === 'string';
-}
-
-/**
- * Determines whether the provided value is a number.
- * @param value Value to inspect.
- * @returns True when the value is a number.
- */
-export function isNumber(value: unknown): value is number {
-  return typeof value === 'number';
-}
-
-/**
- * Determines whether the provided value is an object excluding null.
- * @param value Value to inspect.
- * @returns True when the value is an object.
- */
-function isObject(value: unknown): value is object {
-  return typeof value === 'object' && value !== null;
-}
-
-/**
- * Determines whether the value is a plain object with a simple prototype chain.
- * @param value Value to inspect.
- * @returns True when the value behaves like a plain object.
- */
-function isPlainObject(
-  value: unknown
-): value is Record<string, unknown> {
-  if (!isObject(value)) return false;
-  const proto = Object.getPrototypeOf(value);
-  return proto === null || Object.getPrototypeOf(proto) === null;
-}
-
-/**
- * Validates that the value matches the DividerOptions contract.
- * @param value Value to inspect.
- * @returns True when the value owns at least one known option key.
- */
-export function isOptions(value: unknown): value is DividerOptions {
-  if (!isPlainObject(value)) return false;
-  const options = value;
-
-  return DIVIDER_OPTION_KEYS.some((key) => Object.hasOwn(options, key));
-}
-
-/**
- * Determines whether the provided array is empty.
- * @param value Array to inspect.
- * @returns True when the array contains no elements.
- */
-export function isEmptyArray<T>(value: readonly T[]): boolean {
-  return Array.isArray(value) && value.length === 0;
-}
-
-/**
- * Determines whether the provided value is a positive integer.
- * @param value Value to inspect.
- * @returns True when the value is an integer greater than zero.
- */
-export function isPositiveInteger(value: unknown): boolean {
-  return typeof value === 'number' && Number.isInteger(value) && value > 0;
-}
-
-/**
- * Determines whether the value is a string or readonly array of strings.
- * @param value Value to inspect.
- * @returns True when the value is a string or an array of strings.
- */
-export function isValidInput(value: unknown): value is DividerInput {
-  return isString(value) || (Array.isArray(value) && value.every(isString));
-}
-
-/**
- * Determines whether the value is a string or a number.
- * @param value Value to inspect.
- * @returns True when the value is a primitive string or number.
- */
-export function isStringOrNumber(value: unknown): value is string | number {
-  return isString(value) || isNumber(value);
-}
-
-/**
- * Determines whether the value is an array populated solely by strings.
- * @param value Value to inspect.
- * @returns True when the value is a string array.
- */
-export function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every(isString);
-}
-
-/**
- * Determines whether the value is a non-empty nested array of strings.
- * @param value Value to inspect.
- * @returns True when the value is a nested string array.
- */
-export function isNestedStringArray(value: unknown): value is string[][] {
-  if (!Array.isArray(value) || value.length === 0) return false;
-  const firstRow = value[0];
-  // WHY: Divider outputs are trusted; checking only the first row avoids
-  // a full scan while still distinguishing nested vs flat arrays.
-  return Array.isArray(firstRow) && firstRow.every((item) => isString(item));
-}
-
-/**
- * Determines whether the provided character is a space or tab.
- * @param value Character to inspect.
- * @returns True when the character is a space or tab.
- */
-export function isSpaceOrTab(value: string): boolean {
-  return value === WHITE_SPACE || value === TAB;
-}
-
-/**
- * Determines whether the provided string contains only whitespace characters.
- * @param value String to inspect.
- * @returns True when the string trims to an empty value.
- */
-export function isWhitespaceOnly(value: string): boolean {
-  return value.trim() === '';
-}
-
-/**
- * Determines whether the provided string is empty.
- * @param value String to inspect.
- * @returns True when the string length is zero.
- */
-export function isEmptyString(value: string): boolean {
-  return value === '';
-}
-
-/**
- * Determines whether the provided value matches the exclude mode `none`.
- * @param value Value to inspect.
- * @returns True when the value equals `none`.
- */
-export function isNoneMode(
-  value: unknown
-): value is typeof DIVIDER_EXCLUDE_MODES.NONE {
-  return value === DIVIDER_EXCLUDE_MODES.NONE;
-}
+export {
+  isNumber,
+  isPlainObject,
+  isPositiveInteger,
+  isString,
+  isStringOrNumber,
+} from '@/utils/guards/primitives';
+export {
+  isEmptyArray,
+  isNestedStringArray,
+  isStringArray,
+} from '@/utils/guards/array';
+export { isValidInput } from '@/utils/guards/divider-input';
+export { isNoneMode, isOptions } from '@/utils/guards/options';
+export {
+  isEmptyString,
+  isSpaceOrTab,
+  isWhitespaceOnly,
+} from '@/utils/guards/whitespace';

--- a/src/utils/option-arguments.ts
+++ b/src/utils/option-arguments.ts
@@ -3,7 +3,8 @@ import type {
   DividerSeparator,
   ExtractedDividerOptions,
 } from '@/types';
-import { isOptions, isStringOrNumber } from '@/utils/is';
+import { isOptions } from '@/utils/guards/options';
+import { isStringOrNumber } from '@/utils/guards/primitives';
 
 /**
  * Extracts trailing options from a mixed argument list.

--- a/src/utils/option-exclude.ts
+++ b/src/utils/option-exclude.ts
@@ -1,7 +1,7 @@
 import type { DividerInferredOptions } from '@/types';
 import type { SegmentPredicate } from '@/utils/option-types';
 import { excludePredicateMap } from '@/utils/exclude-predicate';
-import { isNoneMode } from '@/utils/is';
+import { isNoneMode } from '@/utils/guards/options';
 
 /**
  * Resolves a segment filter for the provided exclude mode.

--- a/src/utils/option-output.ts
+++ b/src/utils/option-output.ts
@@ -3,7 +3,8 @@ import type {
   SegmentPredicate,
   SegmentTransformer,
 } from '@/utils/option-types';
-import { isEmptyString, isNestedStringArray } from '@/utils/is';
+import { isNestedStringArray } from '@/utils/guards/array';
+import { isEmptyString } from '@/utils/guards/whitespace';
 
 /**
  * Maps divider output while preserving its flat or nested shape.

--- a/src/utils/option-transformers.ts
+++ b/src/utils/option-transformers.ts
@@ -6,7 +6,7 @@ import {
   mapDividerOutput,
   trimSegments,
 } from '@/utils/option-output';
-import { isNestedStringArray } from '@/utils/is';
+import { isNestedStringArray } from '@/utils/guards/array';
 
 /**
  * Trims segments when the `trim` option is enabled.

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -1,4 +1,6 @@
-import { isEmptyArray, isEmptyString, isNumber } from '@/utils/is';
+import { isEmptyArray } from '@/utils/guards/array';
+import { isNumber } from '@/utils/guards/primitives';
+import { isEmptyString } from '@/utils/guards/whitespace';
 import { getRegex } from '@/utils/regex';
 import { sliceByIndexes } from '@/utils/slice';
 import { sortAscending } from '@/utils/sort';

--- a/src/utils/quoted-parser.ts
+++ b/src/utils/quoted-parser.ts
@@ -1,6 +1,6 @@
 import { countUnescaped } from '@/utils/count-unescaped';
 import { dividePreserve } from '@/utils/divide-preserve';
-import { isEmptyString } from '@/utils/is';
+import { isEmptyString } from '@/utils/guards/whitespace';
 import { stripOuterQuotes } from '@/utils/strip-outer-quotes';
 
 /**

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -1,4 +1,5 @@
-import { isEmptyArray, isEmptyString } from '@/utils/is';
+import { isEmptyArray } from '@/utils/guards/array';
+import { isEmptyString } from '@/utils/guards/whitespace';
 import { PERFORMANCE_CONSTANTS, CACHE_KEY_SEPARATOR } from '@/constants';
 
 // WHY: Normalizing separators (dedupe + remove empties) is needed both for

--- a/src/utils/separator.ts
+++ b/src/utils/separator.ts
@@ -1,5 +1,5 @@
 import type { DividerSeparators } from '@/types';
-import { isString, isNumber } from '@/utils/is';
+import { isNumber, isString } from '@/utils/guards/primitives';
 
 /**
  * Classifies a mixed array of strings and numbers into separate arrays.

--- a/src/utils/slice.ts
+++ b/src/utils/slice.ts
@@ -1,4 +1,4 @@
-import { isEmptyArray } from '@/utils/is';
+import { isEmptyArray } from '@/utils/guards/array';
 
 /**
  * Slices a string into segments based on an array of index positions.

--- a/src/utils/strip-outer-quotes.ts
+++ b/src/utils/strip-outer-quotes.ts
@@ -1,4 +1,4 @@
-import { isSpaceOrTab } from '@/utils/is';
+import { isSpaceOrTab } from '@/utils/guards/whitespace';
 
 const findNonSpaceBounds = (text: string) => {
   let left = 0;

--- a/src/utils/transform-divider-input.ts
+++ b/src/utils/transform-divider-input.ts
@@ -6,7 +6,7 @@ import type {
   DividerResult,
   DividerStringResult,
 } from '@/types';
-import { isString } from '@/utils/is';
+import { isString } from '@/utils/guards/primitives';
 import { applyDividerOptions } from '@/utils/option';
 
 /**

--- a/tests/types/divider-contract.test.ts
+++ b/tests/types/divider-contract.test.ts
@@ -1,4 +1,24 @@
-import { divider } from '../../src';
+import {
+  csvDivider,
+  divider,
+  dividerFirst,
+  dividerLast,
+  dividerLoop,
+  dividerNumberString,
+  emailDivider,
+  pathDivider,
+  queryDivider,
+} from '../../src';
+import type {
+  CsvDividerOptions,
+  DividerArrayResult,
+  DividerLoopOptions,
+  DividerOptions,
+  DividerStringResult,
+  EmailDividerOptions,
+  PathDividerOptions,
+  QueryDividerOptions,
+} from '../../src';
 
 const expectType = <TExpected>(value: TExpected): void => {
   void value;
@@ -23,5 +43,67 @@ describe('divider type contract', () => {
     );
 
     expect(true).toBe(true);
+  });
+});
+
+describe('root public API contract', () => {
+  it('exports divider functions with stable return types', () => {
+    expectType<DividerStringResult[number]>(dividerFirst('a,b', ','));
+    expectType<DividerStringResult[number]>(dividerLast('a,b', ','));
+    expectType<DividerStringResult>(dividerLoop('abcdef', 2));
+    expectType<DividerArrayResult>(dividerLoop(['abcdef'], 2));
+    expectType<DividerStringResult>(
+      dividerLoop(['abcdef'], 2, { flatten: true }),
+    );
+    expectType<DividerStringResult>(dividerNumberString('a1'));
+    expectType<DividerArrayResult>(dividerNumberString(['a1']));
+    expectType<DividerStringResult>(
+      dividerNumberString(['a1'], { flatten: true }),
+    );
+
+    expectType<DividerStringResult>(csvDivider('a,b'));
+    expectType<DividerStringResult>(emailDivider('name@example.com'));
+    expectType<DividerStringResult>(pathDivider('/a/b'));
+    expectType<DividerArrayResult>(queryDivider('a=1&b=2'));
+
+    expect(true).toBe(true);
+  });
+
+  it('exports public option types from the root entry point', () => {
+    const dividerOptions: DividerOptions = {
+      flatten: true,
+      trim: true,
+      preserveEmpty: true,
+      exclude: 'none',
+    };
+    const loopOptions: DividerLoopOptions = {
+      flatten: true,
+      maxChunks: 2,
+      startOffset: 1,
+    };
+    const csvOptions: CsvDividerOptions = {
+      delimiter: ',',
+      quoteChar: '"',
+      trim: true,
+    };
+    const emailOptions: EmailDividerOptions = {
+      splitTLD: true,
+      trim: true,
+    };
+    const pathOptions: PathDividerOptions = {
+      collapse: true,
+      trim: true,
+    };
+    const queryOptions: QueryDividerOptions = {
+      mode: 'auto',
+      trim: true,
+    };
+
+    expectType<DividerOptions>(dividerOptions);
+    expectType<DividerLoopOptions>(loopOptions);
+    expectType<CsvDividerOptions>(csvOptions);
+    expectType<EmailDividerOptions>(emailOptions);
+    expectType<PathDividerOptions>(pathOptions);
+    expectType<QueryDividerOptions>(queryOptions);
   });
 });


### PR DESCRIPTION
## Summary

Split guard utilities by concern.

<!-- A brief summary of the changes -->

## Description

- Expanded root public API contract tests for exported divider functions and option types.
- Split broad `src/utils/is.ts` guard implementations into focused guard modules.
- Kept `src/utils/is.ts` as a compatibility barrel while updating internal imports to use narrower modules directly.

<!-- A detailed explanation of the changes, including why they are needed -->
