### PR TITLE
refactor: normalize divider options before applying transforms

### DIFF
--- a/src/utils/option-transformers.ts
+++ b/src/utils/option-transformers.ts
@@ -1,5 +1,7 @@
-import type { DividerInferredOptions } from '@/types';
-import type { DividerOutput } from '@/utils/option-types';
+import type {
+  DividerOutput,
+  ResolvedDividerOptions,
+} from '@/utils/option-types';
 import { resolveExcludePredicate } from '@/utils/option-exclude';
 import {
   filterDividerOutput,
@@ -17,12 +19,11 @@ import { isNestedStringArray } from '@/utils/guards/array';
  */
 export function applyTrimOption(
   output: DividerOutput,
-  options: DividerInferredOptions,
-  shouldPreserveEmpty: boolean,
+  options: ResolvedDividerOptions,
 ): DividerOutput {
   if (!options.trim) return output;
   return mapDividerOutput(output, (segments) =>
-    trimSegments(segments, shouldPreserveEmpty),
+    trimSegments(segments, options.preserveEmpty),
   );
 }
 
@@ -34,7 +35,7 @@ export function applyTrimOption(
  */
 export function applyFlattenOption(
   output: DividerOutput,
-  options: DividerInferredOptions,
+  options: ResolvedDividerOptions,
 ): DividerOutput {
   return options.flatten && isNestedStringArray(output) ? output.flat() : output;
 }
@@ -48,11 +49,10 @@ export function applyFlattenOption(
  */
 export function applyExcludeOption(
   output: DividerOutput,
-  options: DividerInferredOptions,
-  shouldPreserveEmpty: boolean,
+  options: ResolvedDividerOptions,
 ): DividerOutput {
   const shouldKeep = resolveExcludePredicate(options.exclude);
   return shouldKeep == null
     ? output
-    : filterDividerOutput(output, shouldKeep, shouldPreserveEmpty);
+    : filterDividerOutput(output, shouldKeep, options.preserveEmpty);
 }

--- a/src/utils/option-types.ts
+++ b/src/utils/option-types.ts
@@ -1,9 +1,18 @@
-import type { DividerArrayResult, DividerStringResult } from '@/types';
+import type {
+  DividerArrayResult,
+  DividerOptions,
+  DividerStringResult,
+} from '@/types';
 
 /**
  * Runtime divider output before generic result casting.
  */
 export type DividerOutput = DividerStringResult | DividerArrayResult;
+
+/**
+ * Internal divider options after defaults and invalid runtime values are resolved.
+ */
+export type ResolvedDividerOptions = Required<DividerOptions>;
 
 /**
  * Transforms a flat row of divider segments.

--- a/src/utils/option.ts
+++ b/src/utils/option.ts
@@ -4,14 +4,46 @@ import type {
   DividerInferredOptions,
   DividerResult,
 } from '@/types';
+import { DIVIDER_EXCLUDE_MODES } from '@/constants';
 import {
   applyExcludeOption,
   applyFlattenOption,
   applyTrimOption,
 } from '@/utils/option-transformers';
-import type { DividerOutput } from '@/utils/option-types';
+import { isString } from '@/utils/guards/primitives';
+import type {
+  DividerOutput,
+  ResolvedDividerOptions,
+} from '@/utils/option-types';
 
 export { extractOptions } from '@/utils/option-arguments';
+
+const DEFAULT_RESOLVED_OPTIONS = {
+  flatten: false,
+  trim: false,
+  preserveEmpty: false,
+  exclude: DIVIDER_EXCLUDE_MODES.NONE,
+} as const satisfies ResolvedDividerOptions;
+
+const isDividerExcludeMode = (
+  value: unknown,
+): value is ResolvedDividerOptions['exclude'] =>
+  isString(value) &&
+  Object.values(DIVIDER_EXCLUDE_MODES).includes(
+    value as ResolvedDividerOptions['exclude'],
+  );
+
+const resolveExcludeMode = (value: unknown): ResolvedDividerOptions['exclude'] =>
+  isDividerExcludeMode(value) ? value : DEFAULT_RESOLVED_OPTIONS.exclude;
+
+const resolveDividerOptions = (
+  options: DividerInferredOptions,
+): ResolvedDividerOptions => ({
+  flatten: options.flatten === true,
+  trim: options.trim === true,
+  preserveEmpty: options.preserveEmpty === true,
+  exclude: resolveExcludeMode(options.exclude),
+});
 
 /**
  * Applies `DividerOptions` to a divided result.
@@ -32,12 +64,12 @@ export function applyDividerOptions<
   result: DividerOutput,
   options: O,
 ): DividerResult<T, O> {
-  const shouldPreserveEmpty = options.preserveEmpty === true;
+  const resolvedOptions = resolveDividerOptions(options);
   let output: DividerOutput = result;
 
-  output = applyTrimOption(output, options, shouldPreserveEmpty);
-  output = applyFlattenOption(output, options);
-  output = applyExcludeOption(output, options, shouldPreserveEmpty);
+  output = applyTrimOption(output, resolvedOptions);
+  output = applyFlattenOption(output, resolvedOptions);
+  output = applyExcludeOption(output, resolvedOptions);
 
   return output as DividerResult<T, O>;
 }


### PR DESCRIPTION
## Summary

Normalize divider options before applying transforms.

<!-- A brief summary of the changes -->

## Description

  - Add an internal `ResolvedDividerOptions` type derived from `Required<DividerOptions>`
  - Normalize divider options once before applying trim, flatten, and exclude transforms
  - Update option transformers to consume resolved options instead of optional user-facing options

<!-- A detailed explanation of the changes, including why they are needed -->
