### PR TITLE
chore: allow changelog bot to apply labels

### DIFF
--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     with:
       changelog_path: CHANGELOG.md
       provider: openai


### PR DESCRIPTION
## Summary

Allow [changelog-bot](https://github.com/nyaomaru/changelog-bot) to apply labels.

<!-- A brief summary of the changes -->

## Description

- Add `issues: write` permission to the changelog update workflow

<!-- A detailed explanation of the changes, including why they are needed -->
