### PR TITLE
fix: separate unit and integration test commands

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -65,7 +65,7 @@ run = "bun test tests-bun"
 
 # Integration test (Node)
 [tasks.test_integration]
-run = "pnpm exec tsx tests/integration/usage.test.ts"
+run = "pnpm run test:integration"
 
 [tasks.publish_npm]
 run = "pnpm publish --access public --no-git-checks"

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
   },
   "scripts": {
     "test": "jest",
+    "test:integration": "tsx tests/integration/usage.test.ts",
     "test:types": "tsc -p tests/tsconfig.json",
     "test:performance": "jest --config jest.performance.config.cjs",
-    "test:unit": "jest --testPathIgnorePatterns=performance",
+    "test:unit": "jest",
     "lint": "eslint .",
     "build": "tsup",
     "prepack": "pnpm run build",

--- a/tests/integration/usage.test.ts
+++ b/tests/integration/usage.test.ts
@@ -1,8 +1,5 @@
+import assert from 'node:assert/strict';
 import { divider } from '@nyaomaru/divider';
 
 const result = divider('hello world', ' ');
-console.log(result);
-
-if (JSON.stringify(result) !== JSON.stringify(['hello', 'world'])) {
-  throw new Error('Integration test failed');
-}
+assert.deepEqual(result, ['hello', 'world']);


### PR DESCRIPTION
## Summary

Separate unit and integration test commands.

<!-- A brief summary of the changes -->

## Description

- prevent unit tests from collecting the standalone integration script
- add a dedicated `test:integration` command
- use strict deep equality in the integration smoke test


<!-- A detailed explanation of the changes, including why they are needed -->
