### PR TITLE
fix: publish package with npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -35,6 +36,4 @@ jobs:
         run: pnpm lint && pnpm test && pnpm run test:types && pnpm build
 
       - name: Publish Package
-        run: pnpm publish --access public --no-git-checks --ignore-scripts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --ignore-scripts


### PR DESCRIPTION
## Summary

Publish package with npm trusted publishing.

<!-- A brief summary of the changes -->

## Description

- use Node.js 24 for npm Trusted Publishing support
- publish with the npm CLI instead of pnpm
- remove the long-lived `NPM_TOKEN`

<!-- A detailed explanation of the changes, including why they are needed -->
