### PR TITLE
refactor: shared divider segment selector

### DIFF
--- a/src/core/divider-first.ts
+++ b/src/core/divider-first.ts
@@ -1,5 +1,4 @@
-import { divider } from '@/core/divider';
-import { getFirstElement } from '@/utils/array';
+import { selectDividerSegment } from '@/core/divider-segment';
 import type { DividerInput, DividerSeparators } from '@/types';
 
 /**
@@ -16,6 +15,5 @@ export function dividerFirst(
   input: DividerInput,
   ...args: DividerSeparators
 ): string {
-  const result = divider(input, ...args, { flatten: true });
-  return getFirstElement(result, '');
+  return selectDividerSegment(input, args, (segments) => segments[0]);
 }

--- a/src/core/divider-last.ts
+++ b/src/core/divider-last.ts
@@ -1,5 +1,4 @@
-import { divider } from '@/core/divider';
-import { getLastElement } from '@/utils/array';
+import { selectDividerSegment } from '@/core/divider-segment';
 import type { DividerInput, DividerSeparators } from '@/types';
 
 /**
@@ -16,6 +15,5 @@ export function dividerLast(
   input: DividerInput,
   ...args: DividerSeparators
 ): string {
-  const result = divider(input, ...args, { flatten: true });
-  return getLastElement(result, '');
+  return selectDividerSegment(input, args, (segments) => segments.at(-1));
 }

--- a/src/core/divider-segment.ts
+++ b/src/core/divider-segment.ts
@@ -1,0 +1,25 @@
+import { divider } from '@/core/divider';
+import type { DividerInput, DividerSeparators } from '@/types';
+
+type DividerSegmentSelector = (segments: readonly string[]) => string | undefined;
+
+/**
+ * Divides input and selects a single segment from the flattened result.
+ *
+ * WHY: `dividerFirst` and `dividerLast` share the same setup: they always
+ * flatten array input before choosing one value. Keeping that flow together
+ * makes their public wrappers only describe which segment they select.
+ *
+ * @param input String or array of strings to divide.
+ * @param args Separators used for division.
+ * @param select Selector applied to the flattened divider result.
+ * @returns Selected segment, or an empty string when no segment exists.
+ */
+export function selectDividerSegment(
+  input: DividerInput,
+  args: DividerSeparators,
+  select: DividerSegmentSelector,
+): string {
+  const result = divider(input, ...args, { flatten: true });
+  return select(result) ?? '';
+}

--- a/src/utils/is.ts
+++ b/src/utils/is.ts
@@ -1,8 +1,5 @@
 export {
-  isNumber,
-  isPlainObject,
   isPositiveInteger,
-  isString,
   isStringOrNumber,
 } from '@/utils/guards/primitives';
 export {

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -27,7 +27,7 @@ export function extractQuery(input: string): string {
  * @param input Raw input string that may contain path, query, or fragment text.
  * @returns Query portion when `?` is a URL boundary; otherwise the input without fragment.
  */
-export function extractQueryFromQuestionMark(input: string): string {
+function extractQueryFromQuestionMark(input: string): string {
   const fragmentIndex = input.indexOf('#');
   const withoutFragment =
     fragmentIndex >= 0 ? input.slice(0, fragmentIndex) : input;


### PR DESCRIPTION
## Summary

Refactor shared divider segment selector.

<!-- A brief summary of the changes -->

## Description

- Add a shared `selectDividerSegment` helper for flattened first/last segment selection
- Refactor `dividerFirst` and `dividerLast` to use the shared core path
- Tighten internal utility exports by removing unused re-exports

<!-- A detailed explanation of the changes, including why they are needed -->
