### PR TITLE
refactor: simplify divider loop chunk handling

### DIFF
--- a/src/core/divider-loop.ts
+++ b/src/core/divider-loop.ts
@@ -1,15 +1,40 @@
 import { isPositiveInteger } from '@/utils/guards/primitives';
 import { generateIndexes } from '@/utils/generate-indexes';
-import { shouldTruncateChunks, truncateChunksToMax } from '@/utils/chunk';
+import { applyMaxChunks } from '@/utils/chunk';
 import type {
   DividerInput,
   DividerLoopEmptyOptions,
+  DividerLoopOptions,
   DividerLoopOptionsLike,
   DividerResult,
 } from '@/types';
 import { divider } from '@/core/divider';
 import { PERFORMANCE_CONSTANTS } from '@/constants';
 import { transformDividerInput } from '@/utils/transform-divider-input';
+
+type ResolvedDividerLoopOptions = Required<
+  Pick<DividerLoopOptions, 'startOffset' | 'maxChunks'>
+>;
+
+const DEFAULT_DIVIDER_LOOP_OPTIONS = {
+  startOffset: PERFORMANCE_CONSTANTS.DEFAULT_START_OFFSET,
+  maxChunks: PERFORMANCE_CONSTANTS.DEFAULT_MAX_CHUNKS,
+} as const satisfies ResolvedDividerLoopOptions;
+
+/**
+ * Resolves loop-specific options to concrete runtime values.
+ * @param options Optional divider loop configuration.
+ * @returns Start offset and max chunk settings with defaults applied.
+ */
+function resolveDividerLoopOptions(
+  options?: DividerLoopOptionsLike
+): ResolvedDividerLoopOptions {
+  return {
+    startOffset:
+      options?.startOffset ?? DEFAULT_DIVIDER_LOOP_OPTIONS.startOffset,
+    maxChunks: options?.maxChunks ?? DEFAULT_DIVIDER_LOOP_OPTIONS.maxChunks,
+  };
+}
 
 /**
  * Splits the input string into chunks based on size and offset,
@@ -30,9 +55,7 @@ function createChunksFromString(
   const indexes = generateIndexes(str, size, startOffset);
   const chunks = divider(str, ...indexes);
 
-  return shouldTruncateChunks(chunks, maxChunks)
-    ? truncateChunksToMax(chunks, maxChunks)
-    : chunks;
+  return applyMaxChunks(chunks, maxChunks);
 }
 
 /**
@@ -64,10 +87,7 @@ export function dividerLoop<
     return [];
   }
 
-  const {
-    startOffset = PERFORMANCE_CONSTANTS.DEFAULT_START_OFFSET,
-    maxChunks = PERFORMANCE_CONSTANTS.DEFAULT_MAX_CHUNKS,
-  } = (options ?? {}) as O;
+  const { startOffset, maxChunks } = resolveDividerLoopOptions(options);
 
   return transformDividerInput(
     input,

--- a/src/utils/chunk.ts
+++ b/src/utils/chunk.ts
@@ -39,3 +39,22 @@ export function truncateChunksToMax(
   const tail = chunks.slice(headCount).join('');
   return [...head, tail];
 }
+
+/**
+ * Applies a max-chunk limit when configured.
+ *
+ * WHY: Callers should not need to duplicate the guard before truncating; this
+ * keeps the "0 means unlimited" contract and tail-merge behavior together.
+ *
+ * @param chunks - The original array of string chunks.
+ * @param maxChunks - The maximum number of chunks to retain.
+ * @returns Original chunks when no limit applies, otherwise truncated chunks.
+ */
+export function applyMaxChunks(
+  chunks: readonly string[],
+  maxChunks: number
+): string[] {
+  return shouldTruncateChunks(chunks, maxChunks)
+    ? truncateChunksToMax(chunks, maxChunks)
+    : [...chunks];
+}

--- a/tests/utils/chunk.test.ts
+++ b/tests/utils/chunk.test.ts
@@ -1,4 +1,5 @@
 import {
+  applyMaxChunks,
   shouldTruncateChunks,
   truncateChunksToMax,
 } from '../../src/utils/chunk';
@@ -78,5 +79,22 @@ describe('truncateChunksToMax', () => {
     const result = truncateChunksToMax(input, 3);
 
     expect(result).toEqual(['a', 'b', 'cd']);
+  });
+});
+
+describe('applyMaxChunks', () => {
+  it('returns a shallow copy when no limit applies', () => {
+    const input = ['a', 'b', 'c'];
+
+    const result = applyMaxChunks(input, 0);
+
+    expect(result).toEqual(input);
+    expect(result).not.toBe(input);
+  });
+
+  it('merges tail chunks when a limit applies', () => {
+    const result = applyMaxChunks(['ab', 'cd', 'ef', 'gh'], 2);
+
+    expect(result).toEqual(['ab', 'cdefgh']);
   });
 });


### PR DESCRIPTION
## Summary

Simplify divider loop chunk handling.

<!-- A brief summary of the changes -->

## Description

- Extract loop option defaulting into a dedicated resolver
- Add `applyMaxChunks` to centralize max chunk truncation behavior
- Cover the new chunk helper with focused unit tests

<!-- A detailed explanation of the changes, including why they are needed -->
