### PR TITLE
refactor: centralize divider input validation

### DIFF
--- a/src/core/divider.ts
+++ b/src/core/divider.ts
@@ -1,7 +1,7 @@
 import type { DividerInput, DividerArgs, DividerReturn } from '@/types';
 import { divideString } from '@/utils/parser';
 import { isEmptyArray } from '@/utils/guards/array';
-import { isValidInput } from '@/utils/guards/divider-input';
+import { isValidInput, warnInvalidInput } from '@/utils/guards/divider-input';
 import { ensureStringArray } from '@/utils/array';
 import { transformDividerInput } from '@/utils/transform-divider-input';
 import { createDividerPlan } from '@/core/divider-plan';
@@ -25,9 +25,7 @@ export function divider<
 export function divider(input: DividerInput, ...args: DividerArgs) {
   // Validate input
   if (!isValidInput(input)) {
-    console.warn(
-      "divider: 'input' must be a string or an array of strings. So returning an empty array.",
-    );
+    warnInvalidInput();
     return [];
   }
 

--- a/src/utils/guards/divider-input.ts
+++ b/src/utils/guards/divider-input.ts
@@ -1,6 +1,9 @@
 import type { DividerInput } from '@/types';
 import { isString } from '@/utils/guards/primitives';
 
+const INVALID_INPUT_WARNING =
+  "divider: 'input' must be a string or an array of strings. So returning an empty array.";
+
 /**
  * Determines whether the value is a string or readonly array of strings.
  * @param value Value to inspect.
@@ -8,4 +11,12 @@ import { isString } from '@/utils/guards/primitives';
  */
 export function isValidInput(value: unknown): value is DividerInput {
   return isString(value) || (Array.isArray(value) && value.every(isString));
+}
+
+/**
+ * Warns when a runtime caller passes an unsupported divider input shape.
+ * @returns Nothing.
+ */
+export function warnInvalidInput(): void {
+  console.warn(INVALID_INPUT_WARNING);
 }

--- a/src/utils/transform-divider-input.ts
+++ b/src/utils/transform-divider-input.ts
@@ -6,6 +6,7 @@ import type {
   DividerResult,
   DividerStringResult,
 } from '@/types';
+import { isValidInput, warnInvalidInput } from '@/utils/guards/divider-input';
 import { isString } from '@/utils/guards/primitives';
 import { applyDividerOptions } from '@/utils/option';
 
@@ -31,6 +32,11 @@ export function transformDividerInput<
   transform: (value: string) => DividerStringResult,
   options?: O,
 ): DividerResult<T, O> {
+  if (!isValidInput(input)) {
+    warnInvalidInput();
+    return [] as DividerResult<T, O>;
+  }
+
   const result: DividerStringResult | DividerArrayResult = isString(input)
     ? transform(input)
     : input.map(transform);

--- a/tests/core/divider-loop.test.ts
+++ b/tests/core/divider-loop.test.ts
@@ -81,6 +81,25 @@ describe('dividerLoop with string', () => {
       })
     ).toEqual([]);
   });
+
+  test('handles invalid input gracefully', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    expect(
+      dividerLoop(
+        null as unknown as string,
+        TEST_SEPARATORS.NUMBERS.SINGLE
+      )
+    ).toEqual([]);
+    expect(
+      dividerLoop(
+        [123] as unknown as readonly string[],
+        TEST_SEPARATORS.NUMBERS.SINGLE
+      )
+    ).toEqual([]);
+
+    warnSpy.mockRestore();
+  });
 });
 
 describe('dividerLoop with string[]', () => {

--- a/tests/core/divider-number-string.test.ts
+++ b/tests/core/divider-number-string.test.ts
@@ -18,6 +18,17 @@ describe('dividerNumberString with string', () => {
   test('handles empty string', () => {
     expect(dividerNumberString(TEST_STRINGS.EMPTY)).toEqual([]);
   });
+
+  test('handles invalid input gracefully', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    expect(dividerNumberString(null as unknown as string)).toEqual([]);
+    expect(
+      dividerNumberString([123] as unknown as readonly string[])
+    ).toEqual([]);
+
+    warnSpy.mockRestore();
+  });
 });
 
 describe('dividerNumberString with string[]', () => {


### PR DESCRIPTION
## Summary

Centralize divider input validation.

<!-- A brief summary of the changes -->

## Description

- Centralize invalid divider input warning behavior in the divider input guard module
- Reuse shared validation from `divider` and `transformDividerInput`
- Add regression coverage for invalid runtime input in `dividerLoop` and `dividerNumberString`

<!-- A detailed explanation of the changes, including why they are needed -->
