### PR TITLE
refactor: reuse compiled string divider

### DIFF
--- a/src/core/divider.ts
+++ b/src/core/divider.ts
@@ -1,5 +1,5 @@
 import type { DividerInput, DividerArgs, DividerReturn } from '@/types';
-import { divideString } from '@/utils/parser';
+import { createStringDivider } from '@/utils/parser';
 import { isEmptyArray } from '@/utils/guards/array';
 import { isValidInput, warnInvalidInput } from '@/utils/guards/divider-input';
 import { ensureStringArray } from '@/utils/array';
@@ -23,23 +23,20 @@ export function divider<
   const TArgs extends DividerArgs,
 >(input: T, ...args: TArgs): DividerReturn<T, TArgs>;
 export function divider(input: DividerInput, ...args: DividerArgs) {
-  // Validate input
   if (!isValidInput(input)) {
     warnInvalidInput();
     return [];
   }
 
-  // Handle empty args case
   if (isEmptyArray(args)) {
     return ensureStringArray(input);
   }
 
   const { numSeparators, strSeparators, options } = createDividerPlan(args);
 
-  const applyDivision = (str: string) =>
-    divideString(str, numSeparators, strSeparators, {
-      preserveEmpty: options.preserveEmpty,
-    });
+  const applyDivision = createStringDivider(numSeparators, strSeparators, {
+    preserveEmpty: options.preserveEmpty,
+  });
 
   return transformDividerInput(input, applyDivision, options);
 }

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -10,6 +10,45 @@ type DivideStringOptions = {
   readonly preserveEmpty?: boolean;
 };
 
+type StringDivider = (input: string) => string[];
+
+/**
+ * Creates a reusable string divider from normalized separator groups.
+ *
+ * WHY: Array input applies the same separators to every string. Sorting numeric
+ * indexes and resolving the separator regex here avoids repeating invariant
+ * setup for each item while keeping the per-string operation focused on slicing.
+ *
+ * @param numSeparators Numeric index positions used to slice each input.
+ * @param strSeparators String delimiters used to split each sliced part.
+ * @param options Division behavior shared by every input.
+ * @returns String transformer that applies the compiled separator configuration.
+ */
+export function createStringDivider(
+  numSeparators: readonly number[],
+  strSeparators: readonly string[],
+  options?: DivideStringOptions,
+): StringDivider {
+  if (hasNoSeparators(numSeparators, strSeparators)) {
+    return (input) => [input];
+  }
+
+  assertValidNumSeparators(numSeparators);
+
+  const sortedNumSeparators = sortAscending(numSeparators);
+  const regex = getRegex(strSeparators);
+  const shouldPreserveEmpty = options?.preserveEmpty === true;
+
+  return (input) => {
+    const parts = sliceByIndexes(input, sortedNumSeparators);
+    const segments = regex ? parts.flatMap((part) => part.split(regex)) : parts;
+
+    return shouldPreserveEmpty
+      ? segments
+      : segments.filter((segment) => !isEmptyString(segment));
+  };
+}
+
 /**
  * Divides a string using both numeric index positions and string delimiters.
  *
@@ -20,34 +59,16 @@ type DivideStringOptions = {
  * @param input - The input string to be divided.
  * @param numSeparators - An array of numeric index positions to slice the string at.
  * @param strSeparators - An array of string delimiters to further split the result.
+ * @param options Division behavior for the input.
  * @returns An array of divided string segments.
  */
 export function divideString(
   input: string,
   numSeparators: readonly number[],
   strSeparators: readonly string[],
-  options?: DivideStringOptions
+  options?: DivideStringOptions,
 ): string[] {
-  if (hasNoSeparators(numSeparators, strSeparators)) {
-    return [input];
-  }
-
-  assertValidNumSeparators(numSeparators);
-
-  // Precompile regex for string separators
-  const regex = getRegex(strSeparators);
-  const shouldPreserveEmpty = options?.preserveEmpty === true;
-
-  // Divide by number delimiters
-  const sortedNumSeparators = sortAscending(numSeparators);
-  const parts: string[] = sliceByIndexes(input, sortedNumSeparators);
-
-  // Divide by string delimiters
-  const segments = regex ? parts.flatMap((part) => part.split(regex)) : parts;
-
-  return shouldPreserveEmpty
-    ? segments
-    : segments.filter((segment) => !isEmptyString(segment));
+  return createStringDivider(numSeparators, strSeparators, options)(input);
 }
 
 /**
@@ -58,7 +79,7 @@ export function divideString(
  */
 const hasNoSeparators = (
   numSeparators: readonly number[],
-  strSeparators: readonly string[]
+  strSeparators: readonly string[],
 ) => isEmptyArray(numSeparators) && isEmptyArray(strSeparators);
 
 /**

--- a/tests/utils/parser.test.ts
+++ b/tests/utils/parser.test.ts
@@ -1,4 +1,26 @@
-import { divideString } from '../../src/utils/parser';
+import {
+  createStringDivider,
+  divideString,
+} from '../../src/utils/parser';
+
+describe('createStringDivider', () => {
+  test('reuses one separator configuration across multiple inputs', () => {
+    const divide = createStringDivider([3], ['-']);
+
+    expect(['abc-def', 'ghi-jkl'].map(divide)).toEqual([
+      ['abc', 'def'],
+      ['ghi', 'jkl'],
+    ]);
+  });
+
+  test('does not mutate numeric separators while compiling them', () => {
+    const separators = [4, 2];
+    const divide = createStringDivider(separators, []);
+
+    expect(divide('abcdef')).toEqual(['ab', 'cd', 'ef']);
+    expect(separators).toEqual([4, 2]);
+  });
+});
 
 describe('divideString', () => {
   test('divide by index positions', () => {


### PR DESCRIPTION
## Summary

Reuse compiled string divider.

<!-- A brief summary of the changes -->

## Description

- compile numeric separators and delimiter regex once per `divider` call
- reuse the compiled string divider across array inputs

<!-- A detailed explanation of the changes, including why they are needed -->
