### PR TITLE
refactor: reuse core divider in path preset

### DIFF
--- a/src/presets/path-divider.ts
+++ b/src/presets/path-divider.ts
@@ -1,7 +1,6 @@
 import { divider } from '@/core/divider';
 import type { DividerStringResult } from '@/types';
 import type { PathDividerOptions } from '@/types/preset';
-import { dividePreserve } from '@/utils/divide-preserve';
 import { isEmptyString } from '@/utils/guards/whitespace';
 import { PATH_SEPARATORS } from '@/constants';
 
@@ -19,40 +18,12 @@ export function pathDivider(
 ): DividerStringResult {
   const { trim = false, collapse = true } = options;
 
+  // WHY: Unlike separator-only paths, an empty path represents one empty
+  // segment regardless of collapse behavior.
   if (isEmptyString(input)) return [''];
 
-  const segments = buildPathSegments(input, collapse);
-  const maybeTrimmed = trimSegments(segments, trim);
-  return applyCollapseRules(maybeTrimmed, collapse);
+  return divider(input, PATH_SEPARATORS.SLASH, PATH_SEPARATORS.ALT, {
+    trim,
+    preserveEmpty: !collapse,
+  });
 }
-
-/**
- * Builds path segments based on collapse behavior.
- * @param input Path string to divide.
- * @param collapse Whether to collapse consecutive separators.
- * @returns Divided path segments.
- */
-const buildPathSegments = (input: string, collapse: boolean) =>
-  collapse
-    ? divider(input, PATH_SEPARATORS.SLASH, PATH_SEPARATORS.ALT)
-    : dividePreserve(input, PATH_SEPARATORS.ALT).flatMap((part) =>
-        dividePreserve(part, PATH_SEPARATORS.SLASH)
-      );
-
-/**
- * Optionally trims path segments based on the `trim` option.
- * @param segments Path segments to process.
- * @param trim Whether to trim each segment.
- * @returns Trimmed segments when enabled; otherwise original segments.
- */
-const trimSegments = (segments: DividerStringResult, trim: boolean) =>
-  trim ? segments.map((segment) => segment.trim()) : segments;
-
-/**
- * Applies collapse rules to remove empty segments when enabled.
- * @param segments Path segments to process.
- * @param collapse Whether to filter empty segments.
- * @returns Segments with empty entries removed when enabled.
- */
-const applyCollapseRules = (segments: DividerStringResult, collapse: boolean) =>
-  collapse ? segments.filter((segment) => !isEmptyString(segment)) : segments;

--- a/tests/presets/path-divider.test.ts
+++ b/tests/presets/path-divider.test.ts
@@ -45,6 +45,19 @@ describe('pathDivider', () => {
     ]);
   });
 
+  it('preserves empty trimmed segments when collapse=false', () => {
+    expect(
+      pathDivider('  / a /   | b / ', { trim: true, collapse: false }),
+    ).toEqual(['', 'a', '', 'b', '']);
+  });
+
+  it('collapses whitespace-only segments after trimming', () => {
+    expect(pathDivider('  / a /   | b / ', { trim: true })).toEqual([
+      'a',
+      'b',
+    ]);
+  });
+
   it('handles empty input', () => {
     expect(pathDivider('', { collapse: false })).toEqual(['']);
     // collapse=true drops empties that arise only from separators,


### PR DESCRIPTION
## Summary

Reuse core `divider` in path preset.

<!-- A brief summary of the changes -->

## Description

Refactors `pathDivider` to use the shared core divider pipeline for splitting, trimming, and empty-segment handling. Preserves the preset’s empty-input behavior and adds regression tests covering trim with both collapse modes.

<!-- A detailed explanation of the changes, including why they are needed -->
